### PR TITLE
[bcmshell.py] Match extra whitespace before prompt in regex

### DIFF
--- a/sonic_sfp/bcmshell.py
+++ b/sonic_sfp/bcmshell.py
@@ -54,7 +54,7 @@ class bcmshell (object):
             raise SyntaxError("bcmshell constructor prompt expects an re string")
         else:
             self.re_prompt = re.compile(prompt, re.MULTILINE)
-            self.re_connectprompt = re.compile("bcmshell\r\n" + prompt, re.MULTILINE)
+            self.re_connectprompt = re.compile("bcmshell\r\n\s*" + prompt, re.MULTILINE)
 
         if timeout <= 0:
             raise ValueError("bcmshell.timeout must be > 0")


### PR DESCRIPTION
New SAI appears to have changed the amount of whitespace in the Broadcom shell.

Previous output: `bcmshell\r\ndrivshell>`

New output: `bcmshell\r\n\r\r\ndrivshell>`

This change caused bcmshell.py to consistently fail.

This PR now matches any additional whitespace between `bcmshell\r\n` and `drivshell>`