### PR TITLE
[sfputilbase]: Add logic to parse the title of port_config.ini file

### DIFF
--- a/sonic_sfp/sfputilbase.py
+++ b/sonic_sfp/sfputilbase.py
@@ -272,7 +272,10 @@ class SfpUtilBase(object):
         # if something already exists
         for line in f:
             line.strip()
+            title = []
             if re.search("^#", line) is not None:
+                # The current format is: # name lanes alias index speed
+                title = line.split()[1:]
                 continue
 
             # Parsing logic for 'port_config.ini' file
@@ -284,7 +287,10 @@ class SfpUtilBase(object):
 
                 bcm_port = str(port_pos_in_file)
 
-                if len(line.split()) == 4:
+                if "index" in title:
+                    fp_port_index = int(line.split()[title.index("index")])
+                # Leave the old code for backward compatibility
+                elif len(line.split()) >= 4:
                     fp_port_index = int(line.split()[3])
                 else:
                     fp_port_index = portname.split("Ethernet").pop()


### PR DESCRIPTION
With adding more columns into the port_config.ini file, the previous
logic of checking len(line.split()) == 4 is no longer valid. With
adding the logic of parsing the title of the file, the port index
could be directly retrieved depending on which column it is.

Signed-off-by: Shu0T1an ChenG <shuche@microsoft.com>