### PR TITLE
More changes for compatibility with both Python 2 and 3

### DIFF
--- a/sonic_eeprom/eeprom_base.py
+++ b/sonic_eeprom/eeprom_base.py
@@ -9,6 +9,8 @@
 # 'burn' as a data name indicates the corresponding number of bytes are to
 # be ignored
 
+from __future__ import print_function
+
 try:
     import exceptions
     import binascii
@@ -35,7 +37,7 @@ class EepromDecoder(object):
         self.lock_file = None
 
     def check_status(self):
-        if self.u <> '':
+        if self.u != '':
             F = open(self.u, "r")
             d = F.readline().rstrip()
             F.close()
@@ -74,14 +76,14 @@ class EepromDecoder(object):
             return struct.pack('>I', crc)
         elif self.checksum_field_size() == 1:
             return struct.pack('>B', crc)
-        print 'checksum type not yet supported'
+        print('checksum type not yet supported')
         exit(1)
 
     def compute_2s_complement(self, e, size):
         crc = 0
         loc = 0
         end = len(e)
-        while loc <> end:
+        while loc != end:
             crc += int('0x' + binascii.b2a_hex(e[loc:loc+size]), 0)
             loc += size
         T = 1 << (size * 8)
@@ -113,7 +115,7 @@ class EepromDecoder(object):
 
         if self.checksum_type() == 'dell-crc':
             return self.compute_dell_crc(e)
-        print 'checksum type not yet supported'
+        print('checksum type not yet supported')
         exit(1)
 
     def is_checksum_valid(self, e):
@@ -147,7 +149,7 @@ class EepromDecoder(object):
                 i = t
             else:
                 i = self.decoder(I[0], t)
-            print "%-20s: %s" %(I[0], i)
+            print("%-20s: %s" %(I[0], i))
 
     def set_eeprom(self, e, cmd_args):
         line = ''
@@ -160,7 +162,7 @@ class EepromDecoder(object):
                 k = k.strip()
                 v = v.strip()
                 if k not in fields:
-                    print "Error: invalid field '%s'" %(k)
+                    print("Error: invalid field '%s'" %(k))
                     exit(1)
                 ndict[k] = v
 
@@ -181,7 +183,7 @@ class EepromDecoder(object):
 
             if len(cmd_args) == 0:
                 if self.is_checksum_field(I):
-                    print ("%-20s: %s " %(I[0], i))
+                    print("%-20s: %s " %(I[0], i))
                     continue
 
                 # prompt for new value
@@ -284,7 +286,7 @@ class EepromDecoder(object):
             ret_mac = ret_mac + 1
 
             if (ret_mac & 0xff000000):
-                print 'Error: increment carries into OUI'
+                print('Error: increment carries into OUI')
                 return ''
 
             mac_octets[5] = hex(ret_mac & 0xff)[2:].zfill(2)
@@ -320,7 +322,7 @@ class EepromDecoder(object):
 
         See also mgmtaddrstr() and switchaddrstr().
         '''
-        print "ERROR: Platform did not implement base_mac_addr()"
+        print("ERROR: Platform did not implement base_mac_addr()")
         raise NotImplementedError
 
     def mgmtaddrstr(self, e):
@@ -352,7 +354,7 @@ class EepromDecoder(object):
         # the platform specific import should have an override of this method
         # to provide the allocated mac range from syseeprom or flash sector or
         # wherever that platform stores this info
-        print "Platform did not indicate allocated mac address range"
+        print("Platform did not indicate allocated mac address range")
         raise NotImplementedError
 
     def serial_number_str(self, e):

--- a/sonic_eeprom/eeprom_tlvinfo.py
+++ b/sonic_eeprom/eeprom_tlvinfo.py
@@ -9,6 +9,8 @@
 # 'burn' as a data name indicates the corresponding number of bytes are to
 # be ignored
 
+from __future__ import print_function
+
 try:
     import exceptions
     import binascii
@@ -84,27 +86,27 @@ class TlvInfoDecoder(eeprom_base.EepromDecoder):
         '''
         if self._TLV_HDR_ENABLED :
             if not self.is_valid_tlvinfo_header(e):
-                print "EEPROM does not contain data in a valid TlvInfo format."
+                print("EEPROM does not contain data in a valid TlvInfo format.")
                 return
 
-            print "TlvInfo Header:"
-            print "   Id String:    %s" % (e[0:7],)
-            print "   Version:      %d" % (ord(e[8]),)
+            print("TlvInfo Header:")
+            print("   Id String:    %s" % (e[0:7],))
+            print("   Version:      %d" % (ord(e[8]),))
             total_len = (ord(e[9]) << 8) | ord(e[10])
-            print "   Total Length: %d" % (total_len,)
+            print("   Total Length: %d" % (total_len,))
             tlv_index = self._TLV_INFO_HDR_LEN
             tlv_end   = self._TLV_INFO_HDR_LEN + total_len
         else :
             tlv_index = self.eeprom_start
             tlv_end   = self._TLV_INFO_MAX_LEN
 
-        print "TLV Name             Code Len Value"
-        print "-------------------- ---- --- -----"
+        print("TLV Name             Code Len Value")
+        print("-------------------- ---- --- -----")
         while (tlv_index + 2) < len(e) and tlv_index < tlv_end:
             if not self.is_valid_tlv(e[tlv_index:]):
-                print "Invalid TLV field starting at EEPROM offset %d" % (tlv_index,)
+                print("Invalid TLV field starting at EEPROM offset %d" % (tlv_index,))
                 return
-            print self.decoder(None, e[tlv_index:tlv_index + 2 + ord(e[tlv_index + 1])])
+            print(self.decoder(None, e[tlv_index:tlv_index + 2 + ord(e[tlv_index + 1])]))
             if ord(e[tlv_index]) == self._TLV_CODE_QUANTA_CRC or \
                ord(e[tlv_index]) == self._TLV_CODE_CRC_32:
                 return
@@ -175,7 +177,7 @@ class TlvInfoDecoder(eeprom_base.EepromDecoder):
                 elif action in ['f', 'F']:
                     pass
                 else:
-                    print "\nInvalid input, please enter 'a', 'm', 'd', or 'f'\n"
+                    print("\nInvalid input, please enter 'a', 'm', 'd', or 'f'\n")
 
         if self._TLV_HDR_ENABLED:
             new_tlvs_len = len(new_tlvs) + 6
@@ -190,7 +192,7 @@ class TlvInfoDecoder(eeprom_base.EepromDecoder):
         elif self._TLV_CODE_QUANTA_CRC != self._TLV_CODE_UNDEFINED:
             new_e = new_e + chr(self._TLV_CODE_QUANTA_CRC) + chr(2)
         else:
-            print "\nFailed to formulate new eeprom\n"
+            print("\nFailed to formulate new eeprom\n")
             exit
         new_e += self.encode_checksum(self.calculate_checksum(new_e))
         self.decode_eeprom(new_e)

--- a/sonic_sfp/bcmshell.py
+++ b/sonic_sfp/bcmshell.py
@@ -5,6 +5,9 @@
 #
 #-------------------------------------------------------------------------------
 #
+
+from __future__ import print_function
+
 try:
     import sys
     import os
@@ -346,7 +349,7 @@ class bcmshell (object):
         s = self.run(cmd)
         if 'Unknown command:' in s:
             raise ValueError(s)
-        print s
+        print(s)
 
                 
     #---------------
@@ -360,20 +363,20 @@ class bcmshell (object):
         if type(d) is dict:
             for I in sorted(d, key=self.__name_conv__):
                 if type(d[I]) is int:
-                    print "%s %30s: " % (s, I),
+                    print("%s %30s: " % (s, I), end=" ")
                 else:
-                    print "%s %s:" % (s, I) 
+                    print("%s %s:" % (s, I))
                 self.prettyprint(d[I], (level + 1))
         elif type(d) is list:
             for I in range(len(d)):
                 i = "[" + str(I) + "]"
                 if type(d[I]) is int or type(d[I]) is long:
-                    print "%s %10s: " % (s, i),
+                    print("%s %10s: " % (s, i), end=" ")
                 else:
-                    print "%s %s:" % (s, i) 
+                    print("%s %s:" % (s, i)) 
                 self.prettyprint(d[I], (level + 1))
         else:
-            print "%s" % (hex(d))
+            print("%s" % (hex(d)))
 
                 
     #---------------
@@ -403,7 +406,8 @@ class bcmshell (object):
         self.__open__()
         try:
             self.socketobj.sendall(cmd + '\n')
-        except socket.error as (errno, errstr):
+        except socket.error as err:
+            (errno, errstr) = err.args
             raise IOError("unable to send command \"%s\", %s" % (cmd, errstr))
 
         self.buffer = ''
@@ -460,7 +464,8 @@ class bcmshell (object):
                     self.socketobj = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
                     self.socketobj.settimeout(self.timeout)
                     self.socketobj.connect(self.socketname)
-                except socket.error as (errno, errstr):
+                except socket.error as err:
+                    (errno, errstr) = err.args
                     if timeout == 0:
                         raise IOError("unable to open %s, %s" % (self.socketname, errstr))
                     time.sleep(1)
@@ -488,7 +493,8 @@ class bcmshell (object):
                         raise IOError("unable to flush %s for %d seconds" %
                                       (self.socketname, self.timeout))
 
-            except socket.error as (errno, errstr):
+            except socket.error as err:
+                (errno, errstr) = err.args
                 raise IOError("Socket error: unable to flush %s on open: %s" % (self.socketname, errstr))
             except IOError as e:
                 raise IOError("unable to flush %s on open: %s" % (self.socketname, e.message))

--- a/sonic_sfp/sff8436.py
+++ b/sonic_sfp/sff8436.py
@@ -3,6 +3,8 @@
 # SFF-8436 QSFP+ 10 Gbs 4X PLUGGABLE TRANSCEIVER
 #----------------------------------------------------------------------------
 
+from __future__ import print_function
+
 try:
     import fcntl
     import struct
@@ -378,7 +380,7 @@ class sff8436InterfaceId(sffbase):
 
     def dump_pretty(self):
         if self.interface_data == None:
-            print 'Object not initialized, nothing to print'
+            print('Object not initialized, nothing to print')
             return
         sffbase.dump_pretty(self, self.interface_data)
 
@@ -455,7 +457,7 @@ class sff8436Dom(sffbase):
                 # Internal Calibration
 
                 result = float(result * 0.0001)
-                #print indent, name, ' : %.4f' %result, 'Volts'
+                #print(indent, name, ' : %.4f' %result, 'Volts')
                 retval = '%.4f' %result + 'Volts'
             elif cal_type == 2:
 
@@ -475,10 +477,10 @@ class sff8436Dom(sffbase):
 
                 result = v_slope * result + v_offset
                 result = float(result * 0.0001)
-                #print indent, name, ' : %.4f' %result, 'Volts'
+                #print(indent, name, ' : %.4f' %result, 'Volts')
                 retval = '%.4f' %result + 'Volts'
             else:
-                #print indent, name, ' : Unknown'
+                #print(indent, name, ' : Unknown')
                 retval = 'Unknown'
         except Exception as err:
             retval = str(err)
@@ -498,7 +500,7 @@ class sff8436Dom(sffbase):
                 # Internal Calibration
 
                 result = float(result * 0.002)
-                #print indent, name, ' : %.4f' %result, 'mA'
+                #print(indent, name, ' : %.4f' %result, 'mA')
                 retval = '%.4f' %result + 'mA'
 
             elif cal_type == 2:
@@ -518,7 +520,7 @@ class sff8436Dom(sffbase):
 
                 result = i_slope * result + i_offset
                 result = float(result * 0.002)
-                #print indent, name, ' : %.4f' %result, 'mA'
+                #print(indent, name, ' : %.4f' %result, 'mA')
                 retval = '%.4f' %result + 'mA'
             else:
                 retval = 'Unknown'
@@ -539,7 +541,7 @@ class sff8436Dom(sffbase):
             if cal_type == 1:
 
                 result = float(result * 0.0001)
-                #print indent, name, ' : ', power_in_dbm_str(result)
+                #print(indent, name, ' : ', power_in_dbm_str(result))
                 retval = self.power_in_dbm_str(result)
 
             elif cal_type == 2:
@@ -579,7 +581,7 @@ class sff8436Dom(sffbase):
 
                 # Internal Calibration
                 result = float(result * 0.0001)
-                #print indent, name, " : ", power_in_dbm_str(result)
+                #print(indent, name, " : ", power_in_dbm_str(result))
                 retval = self.power_in_dbm_str(result)
 
             elif cal_type == 2:
@@ -629,7 +631,7 @@ class sff8436Dom(sffbase):
                 rx_pwr = (rx_pwr_4 * result) + (rx_pwr_3 * result) + (rx_pwr_2 * result) + (rx_pwr_1 * result) + rx_pwr_0
 
                 result = float(result * 0.0001)
-                #print indent, name, " : ", power_in_dbm_str(result)
+                #print(indent, name, " : ", power_in_dbm_str(result))
                 retval = self.power_in_dbm_str(result)
             else:
                 retval = 'Unknown'
@@ -936,7 +938,7 @@ class sff8436Dom(sffbase):
 
     def dump_pretty(self):
         if self.dom_data == None:
-            print 'Object not initialized, nothing to print'
+            print('Object not initialized, nothing to print')
             return
         sffbase.dump_pretty(self, self.dom_data)
 

--- a/sonic_sfp/sff8472.py
+++ b/sonic_sfp/sff8472.py
@@ -4,6 +4,9 @@
 # Copyright 2012 Cumulus Networks, inc  all rights reserved
 #
 #--------------------------------------------------------------------------
+
+from __future__ import print_function
+
 try:
     import fcntl
     import struct
@@ -451,7 +454,7 @@ class sff8472InterfaceId(sffbase):
 
     def dump_pretty(self):
         if self.interface_data == None:
-            print 'Object not initialized, nothing to print'
+            print('Object not initialized, nothing to print')
             return
         sffbase.dump_pretty(self, self.interface_data)
 
@@ -570,7 +573,7 @@ class sff8472Dom(sffbase):
                 # Internal Calibration
 
                 result = float(result * 0.0001)
-                #print indent, name, ' : %.4f' %result, 'Volts'
+                #print(indent, name, ' : %.4f' %result, 'Volts')
                 retval = '%.4f' %result + 'Volts'
             elif cal_type == 2:
 
@@ -590,10 +593,10 @@ class sff8472Dom(sffbase):
 
                 result = v_slope * result + v_offset
                 result = float(result * 0.0001)
-                #print indent, name, ' : %.4f' %result, 'Volts'
+                #print(indent, name, ' : %.4f' %result, 'Volts')
                 retval = '%.4f' %result + 'Volts'
             else:
-                #print indent, name, ' : Unknown'
+                #print(indent, name, ' : Unknown')
                 retval = 'Unknown'
         except Exception as err:
             retval = str(err)
@@ -613,7 +616,7 @@ class sff8472Dom(sffbase):
                 # Internal Calibration
 
                 result = float(result * 0.002)
-                #print indent, name, ' : %.4f' %result, 'mA'
+                #print(indent, name, ' : %.4f' %result, 'mA')
                 retval = '%.4f' %result + 'mA'
 
             elif cal_type == 2:
@@ -633,7 +636,7 @@ class sff8472Dom(sffbase):
 
                 result = i_slope * result + i_offset
                 result = float(result * 0.002)
-                #print indent, name, ' : %.4f' %result, 'mA'
+                #print(indent, name, ' : %.4f' %result, 'mA')
                 retval = '%.4f' %result + 'mA'
             else:
                 retval = 'Unknown'
@@ -654,7 +657,7 @@ class sff8472Dom(sffbase):
             if cal_type == 1:
 
                 result = float(result * 0.0001)
-                #print indent, name, ' : ', power_in_dbm_str(result)
+                #print(indent, name, ' : ', power_in_dbm_str(result))
                 retval = self.power_in_dbm_str(result)
 
             elif cal_type == 2:
@@ -694,7 +697,7 @@ class sff8472Dom(sffbase):
 
                 # Internal Calibration
                 result = float(result * 0.0001)
-                #print indent, name, " : ", power_in_dbm_str(result)
+                #print(indent, name, " : ", power_in_dbm_str(result))
                 retval = self.power_in_dbm_str(result)
 
             elif cal_type == 2:
@@ -744,7 +747,7 @@ class sff8472Dom(sffbase):
                 rx_pwr = (rx_pwr_4 * result) + (rx_pwr_3 * result) + (rx_pwr_2 * result) + (rx_pwr_1 * result) + rx_pwr_0
 
                 result = float(result * 0.0001)
-                #print indent, name, " : ", power_in_dbm_str(result)
+                #print(indent, name, " : ", power_in_dbm_str(result))
                 retval = self.power_in_dbm_str(result)
             else:
                 retval = 'Unknown'
@@ -1037,7 +1040,7 @@ class sff8472Dom(sffbase):
 
     def dump_pretty(self):
         if self.dom_data == None:
-            print 'Object not initialized, nothing to print'
+            print('Object not initialized, nothing to print')
             return
         sffbase.dump_pretty(self, self.dom_data)
 

--- a/sonic_sfp/sffbase.py
+++ b/sonic_sfp/sffbase.py
@@ -3,6 +3,8 @@
 # sffbase class for sff8436 and sff8472
 #----------------------------------------------------------------------------
 
+from __future__ import print_function
+
 try:
     import fcntl
     import struct
@@ -232,19 +234,18 @@ class sffbase(object):
     def dump_pretty(self, indict):
         for elem, elem_val in sorted(indict.iteritems()):
             if type(elem_val) == types.DictType:
-                print self._indent, elem, ': '
+                print(self._indent, elem, ': ')
                 self.inc_indent()
                 sff8472.dump_pretty(self, elem_val)
                 self.dec_indent()
             elif type(elem_val) == types.ListType:
                 if len(elem_val) == 1:
-                    print (self._indent, elem, ': ',
-                        elem_val.pop())
+                    print(self._indent, elem, ': ', elem_val.pop())
                 else:
-                    print self._indent, elem, ': '
+                    print(self._indent, elem, ': ')
                     self.inc_indent()
                     for e in elem_val:
-                        print self._indent, e
+                        print(self._indent, e)
                     self.dec_indent()
             else:
-                print self._indent, elem, ': ', elem_val
+                print(self._indent, elem, ': ', elem_val)

--- a/sonic_sfp/sfputilbase.py
+++ b/sonic_sfp/sfputilbase.py
@@ -3,6 +3,8 @@
 # Base class for creating platform-specific SFP transceiver interfaces for SONiC
 #
 
+from __future__ import print_function
+
 try:
     import abc
     import binascii
@@ -133,7 +135,7 @@ class SfpUtilBase(object):
             nd_file.close()
 
         except Exception as err:
-            print "Error writing to new device file: %s" % str(err)
+            print("Error writing to new device file: %s" % str(err))
             return 1
         else:
             return 0
@@ -143,14 +145,13 @@ class SfpUtilBase(object):
     def _delete_sfp_device(self, sysfs_sfp_i2c_adapter_path, devaddr):
         try:
             sysfs_nd_path = "%s/delete_device" % sysfs_sfp_i2c_adapter_path
-            print devaddr > sysfs_nd_path
 
             # Write device address to delete_device file
             nd_file = open(sysfs_nd_path, "w")
             nd_file.write(devaddr)
             nd_file.close()
         except Exception as err:
-            print "Error writing to new device file: %s" % str(err)
+            print("Error writing to new device file: %s" % str(err))
             return 1
         else:
             return 0
@@ -191,7 +192,7 @@ class SfpUtilBase(object):
 
             i2c_adapter_id = self._get_port_i2c_adapter_id(port_num)
             if i2c_adapter_id is None:
-                print "Error getting i2c bus num"
+                print("Error getting i2c bus num")
                 return None
 
             # Get i2c virtual bus path for the sfp
@@ -200,7 +201,7 @@ class SfpUtilBase(object):
 
             # If i2c bus for port does not exist
             if not os.path.exists(sysfs_sfp_i2c_adapter_path):
-                print "Could not find i2c bus %s. Driver not loaded?" % sysfs_sfp_i2c_adapter_path
+                print("Could not find i2c bus %s. Driver not loaded?" % sysfs_sfp_i2c_adapter_path)
                 return None
 
             sysfs_sfp_i2c_client_path = "%s/%s-00%s" % (sysfs_sfp_i2c_adapter_path,
@@ -212,7 +213,7 @@ class SfpUtilBase(object):
                 ret = self._add_new_sfp_device(
                         sysfs_sfp_i2c_adapter_path, devid)
                 if ret != 0:
-                    print "Error adding sfp device"
+                    print("Error adding sfp device")
                     return None
 
             sysfs_sfp_i2c_client_eeprom_path = "%s/eeprom" % sysfs_sfp_i2c_client_path
@@ -225,7 +226,7 @@ class SfpUtilBase(object):
             sysfsfile_eeprom.seek(offset)
             raw = sysfsfile_eeprom.read(num_bytes)
         except IOError:
-            print "Error: reading sysfs file %s" % sysfs_sfp_i2c_client_eeprom_path
+            print("Error: reading sysfs file %s" % sysfs_sfp_i2c_client_eeprom_path)
             return None
 
         try:
@@ -341,10 +342,10 @@ class SfpUtilBase(object):
         self.physical_to_logical = physical_to_logical
 
         """
-        print "logical: " +  self.logical
-        print "logical to bcm: " + self.logical_to_bcm
-        print "logical to physical: " + self.logical_to_physical
-        print "physical to logical: " + self.physical_to_logical
+        print("logical: " + self.logical)
+        print("logical to bcm: " + self.logical_to_bcm)
+        print("logical to physical: " + self.logical_to_physical)
+        print("physical to logical: " + self.physical_to_logical)
         """
 
     def read_phytab_mappings(self, phytabfile):
@@ -433,11 +434,11 @@ class SfpUtilBase(object):
         pp = pprint.PrettyPrinter(indent=4)
         pp.pprint(self.phytab_mappings)
 
-        print "logical: " +  self.logical
-        print "logical to bcm: " +  self.logical_to_bcm
-        print "phytab mappings: " + self.phytab_mappings
-        print "physical to logical: " + self.physical_to_logical
-        print "physical to phyaddrs: " + self.physical_to_phyaddrs
+        print("logical: " +  self.logical)
+        print("logical to bcm: " +  self.logical_to_bcm)
+        print("phytab mappings: " + self.phytab_mappings)
+        print("physical to logical: " + self.physical_to_logical)
+        print("physical to phyaddrs: " + self.physical_to_phyaddrs)
         """
 
     def get_physical_to_logical(self, port_num):


### PR DESCRIPTION
We are packaging sonic-platform-common as both a Python 2 wheel and Python 3 wheel. Currently, with Python 3 we only use sonic_psu in the SNMP docker, which is already compliant with both Python 2 and 3.

However, when installing the Python 3 package, I noticed there were multiple error messages because of eeprom and sfp files which were not Python 3-compatible. Since the Python 3 implementation of these files is not currently used, no issues were presented in the image itself.

This PR causes both the Python 2 and Python 3 wheel packages to build and install without any errors.