### PR TITLE
[sfp] add 256 to offset for dumping DDM of sfp+.

### DIFF
--- a/sonic_sfp/sfputilbase.py
+++ b/sonic_sfp/sfputilbase.py
@@ -223,6 +223,8 @@ class SfpUtilBase(object):
 
         try:
             sysfsfile_eeprom = open(sysfs_sfp_i2c_client_eeprom_path, "rb")
+            if devid == self.DOM_EEPROM_ADDR:
+                offset += 256
             sysfsfile_eeprom.seek(offset)
             raw = sysfsfile_eeprom.read(num_bytes)
         except IOError:


### PR DESCRIPTION
For the SFP+ with DDM, the device file, "eeprom", contains 256*2 bytes.
To dump SFF-8472 part, addressed 256 ~ 511, the start offset must be 256.

Example: 
root@sonic:/home/admin# hd /sys/bus/i2c/devices/2-0050/eeprom
00000000  03 04 07 10 00 00 00 00  00 00 00 06 67 00 00 00  |............g...|
..........
*
00000100  5f 00 e7 00 5a 00 ec 00  94 70 6d 60 90 88 71 48  |_...Z....pm`..qH|
.......
*
000001f0  ff ff ff ff ff ff ff ff  00 00 00 00 00 00 00 00  |................|
00000200

Signed-off-by: roy_lee <roy_lee@accton.com>