### PR TITLE
[sfputilbase]: enhance the sfputilbase for transceiver monitoring

### DIFF
--- a/sonic_sfp/sff8436.py
+++ b/sonic_sfp/sff8436.py
@@ -400,6 +400,26 @@ class sff8436InterfaceId(sffbase):
              'type': 'str'}
         }
 
+    qsfp_dom_capability = {
+        'Tx_power_support':
+            {'offset': 0,
+             'bit': 2,
+             'type': 'bitvalue'},
+        'Rx_power_support':
+            {'offset': 0,
+             'bit': 3,
+             'type': 'bitvalue'},
+        'Voltage_support':
+            {'offset': 0,
+             'bit': 4,
+             'type': 'bitvalue'},
+        'Temp_support':
+            {'offset': 0,
+             'bit': 5,
+             'type': 'bitvalue'}
+        }
+    
+
     def __init__(self, eeprom_raw_data=None):
         self.interface_data = None
         start_pos = 128
@@ -427,6 +447,9 @@ class sff8436InterfaceId(sffbase):
 
     def parse_vendor_sn(self, sn_raw_data, start_pos):
         return sffbase.parse(self, self.vendor_sn, sn_raw_data, start_pos)
+
+    def parse_qsfp_dom_capability(self, sn_raw_data, start_pos):
+        return sffbase.parse(self, self.qsfp_dom_capability, sn_raw_data, start_pos)
 
     def dump_pretty(self):
         if self.interface_data == None:
@@ -689,7 +712,6 @@ class sff8436Dom(sffbase):
             retval = str(err)
 
         return retval
-
 
     dom_status_indicator = {'DataNotReady':
                 {'offset': 2,
@@ -974,6 +996,25 @@ class sff8436Dom(sffbase):
 
 # new added parser for some specific values interested by SNMP
 # TO DO: find a way to reuse the definitions in above code, need refactor
+    revision_compliance = {
+        '00': 'Revision not specified',
+        '01': 'SFF-8436 Rev 4.8',
+        '02': 'SFF-8436 Rev 4.8 with extra bytes support',
+        '03': 'SFF-8636 Rev 1.3',
+        '04': 'SFF-8636 Rev 1.4',
+        '05': 'SFF-8636 Rev 1.5',
+        '06': 'SFF-8636 Rev 2.0',
+        '07': 'SFF-8636 Rev 2.5'
+        }
+
+    sfp_dom_rev = {
+        'dom_rev':
+            {'offset': 0,
+             'size': 1,
+             'type': 'enum',
+             'decode': revision_compliance}
+        }
+
     dom_module_temperature = {
         'Temperature':
             {'offset': 0,
@@ -1033,6 +1074,69 @@ class sff8436Dom(sffbase):
              'decode': {'func': calc_bias}}
         }
 
+    dom_channel_monitor_params_with_tx_power = {
+        'RX1Power':
+            {'offset': 0,
+             'size': 2,
+             'type': 'func',
+             'decode': {'func': calc_rx_power}},
+        'RX2Power':
+            {'offset': 2,
+             'size': 2,
+             'type': 'func',
+             'decode': {'func': calc_rx_power}},
+        'RX3Power':
+            {'offset': 4,
+             'size': 2,
+             'type': 'func',
+             'decode': {'func': calc_rx_power}},
+        'RX4Power':
+            {'offset': 6,
+             'size': 2,
+             'type': 'func',
+             'decode': {'func': calc_rx_power}},
+        'TX1Bias':
+            {'offset': 8,
+             'size': 2,
+             'type': 'func',
+             'decode': {'func': calc_bias}},
+        'TX2Bias':
+            {'offset': 10,
+             'size': 2,
+             'type': 'func',
+             'decode': {'func': calc_bias}},
+        'TX3Bias':
+            {'offset': 12,
+             'size': 2,
+             'type': 'func',
+             'decode': {'func': calc_bias}},
+        'TX4Bias':
+            {'offset': 14,
+             'size': 2,
+             'type': 'func',
+             'decode': {'func': calc_bias}},
+        'TX1Power':
+            {'offset': 0,
+             'size': 2,
+             'type': 'func',
+             'decode': {'func': calc_tx_power}},
+        'TX2Power':
+            {'offset': 2,
+             'size': 2,
+             'type': 'func',
+             'decode': {'func': calc_tx_power}},
+        'TX3Power':
+            {'offset': 4,
+             'size': 2,
+             'type': 'func',
+             'decode': {'func': calc_tx_power}},
+        'TX4Power':
+            {'offset': 6,
+             'size': 2,
+             'type': 'func',
+             'decode': {'func': calc_tx_power}}
+        }
+
     def __init__(self, eeprom_raw_data=None, calibration_type=1):
         self._calibration_type = calibration_type
         start_pos = 0
@@ -1046,6 +1150,9 @@ class sff8436Dom(sffbase):
                     start_pos)
 
 # Parser functions for specific values interested by SNMP
+    def parse_sfp_dom_rev(self, type_raw_data, start_pos):
+        return sffbase.parse(self, self.sfp_dom_rev, type_raw_data, start_pos)
+
     def parse_temperature(self, eeprom_raw_data, start_pos):
         return sffbase.parse(self, self.dom_module_temperature, eeprom_raw_data,
                     start_pos)
@@ -1056,6 +1163,10 @@ class sff8436Dom(sffbase):
 
     def parse_channel_monitor_params(self, eeprom_raw_data, start_pos):
         return sffbase.parse(self, self.dom_channel_monitor_params, eeprom_raw_data,
+                    start_pos)
+
+    def parse_channel_monitor_params_with_tx_power(self, eeprom_raw_data, start_pos):
+        return sffbase.parse(self, self.dom_channel_monitor_params_with_tx_power, eeprom_raw_data,
                     start_pos)
 
     def dump_pretty(self):

--- a/sonic_sfp/sff8436.py
+++ b/sonic_sfp/sff8436.py
@@ -364,6 +364,41 @@ class sff8436InterfaceId(sffbase):
                  'type'  : 'bitmap',
                  'decode': {}}}
 
+    sfp_type = {
+        'type':
+            {'offset':0,
+             'size':1,
+             'type' : 'enum',
+             'decode' : type_of_transceiver}
+        }
+
+    vendor_name = {
+        'Vendor Name':
+            {'offset' : 0,
+             'size': 16,
+             'type': 'str'}
+        }
+
+    vendor_pn = {
+        'Vendor PN':
+            {'offset': 0,
+             'size'  : 16,
+             'type'  : 'str'}
+        }
+
+    vendor_rev = {
+        'Vendor Rev':
+            {'offset': 0,
+             'size'  : 2,
+             'type'  : 'str'}
+        }
+
+    vendor_sn = {
+        'Vendor SN':
+            {'offset': 0,
+             'size'  : 16,
+             'type'  : 'str'}
+        }
 
     def __init__(self, eeprom_raw_data=None):
         self.interface_data = None
@@ -377,6 +412,21 @@ class sff8436InterfaceId(sffbase):
 
     def parse(self, eeprom_raw_data, start_pos):
         return sffbase.parse(self, self.interface_id, eeprom_raw_data, start_pos)
+
+    def parse_sfp_type(self, type_raw_data, start_pos):
+        return sffbase.parse(self, self.sfp_type, type_raw_data, start_pos)
+
+    def parse_vendor_name(self, name_raw_data, start_pos):
+        return sffbase.parse(self, self.vendor_name, name_raw_data, start_pos)
+
+    def parse_vendor_rev(self, rev_raw_data, start_pos):
+        return sffbase.parse(self, self.vendor_rev, rev_raw_data, start_pos)
+
+    def parse_vendor_pn(self, pn_raw_data, start_pos):
+        return sffbase.parse(self, self.vendor_pn, pn_raw_data, start_pos)
+
+    def parse_vendor_sn(self, sn_raw_data, start_pos):
+        return sffbase.parse(self, self.vendor_sn, sn_raw_data, start_pos)
 
     def dump_pretty(self):
         if self.interface_data == None:
@@ -857,7 +907,6 @@ class sff8436Dom(sffbase):
                  'bit': 0,
                  'type': 'bitvalue'}}
 
-
     dom_module_monitor_values = {'Temperature':
                 {'offset':22,
                  'size':2,
@@ -923,6 +972,66 @@ class sff8436Dom(sffbase):
              'type': 'nested',
              'decode': dom_channel_monitor_values}}
 
+# new added parser for some specific values interested by SNMP
+# TO DO: find a way to reuse the definitions in above code, need refactor
+    dom_module_temperature = {
+        'Temperature':
+            {'offset':0,
+             'size':2,
+             'type': 'func',
+             'decode': {'func':calc_temperature}}
+        }
+
+    dom_module_voltage = {
+        'Vcc':
+            {'offset':0,
+             'size':2,
+             'type': 'func',
+             'decode': { 'func':calc_voltage}}
+        }
+
+    dom_channel_monitor_params = {
+        'RX1Power':
+            {'offset':0,
+             'size':2,
+             'type': 'func',
+             'decode': { 'func':calc_rx_power}},
+        'RX2Power':
+            {'offset':2,
+             'size':2,
+             'type': 'func',
+             'decode': { 'func':calc_rx_power}},
+        'RX3Power':
+            {'offset':4,
+             'size':2,
+             'type': 'func',
+             'decode': { 'func':calc_rx_power}},
+        'RX4Power':
+            {'offset':6,
+             'size':2,
+             'type': 'func',
+             'decode': { 'func':calc_rx_power}},
+        'TX1Bias':
+            {'offset':8,
+             'size':2,
+             'type': 'func',
+             'decode': { 'func':calc_bias}},
+        'TX2Bias':
+            {'offset':10,
+             'size':2,
+             'type': 'func',
+             'decode': { 'func':calc_bias}},
+        'TX3Bias':
+            {'offset':12,
+             'size':2,
+             'type': 'func',
+             'decode': { 'func':calc_bias}},
+        'TX4Bias':
+            {'offset':14,
+             'size':2,
+             'type': 'func',
+             'decode': { 'func':calc_bias}}
+        }
 
     def __init__(self, eeprom_raw_data=None, calibration_type=1):
         self._calibration_type = calibration_type
@@ -934,6 +1043,19 @@ class sff8436Dom(sffbase):
 
     def parse(self, eeprom_raw_data, start_pos):
         return sffbase.parse(self, self.dom_map, eeprom_raw_data,
+                    start_pos)
+
+# Parser functions for specific values interested by SNMP
+    def parse_temperature(self, eeprom_raw_data, start_pos):
+        return sffbase.parse(self, self.dom_module_temperature, eeprom_raw_data,
+                    start_pos)
+
+    def parse_voltage(self, eeprom_raw_data, start_pos):
+        return sffbase.parse(self, self.dom_module_voltage, eeprom_raw_data,
+                    start_pos)
+
+    def parse_channel_monitor_params(self, eeprom_raw_data, start_pos):
+        return sffbase.parse(self, self.dom_channel_monitor_params, eeprom_raw_data,
                     start_pos)
 
     def dump_pretty(self):

--- a/sonic_sfp/sff8436.py
+++ b/sonic_sfp/sff8436.py
@@ -366,15 +366,15 @@ class sff8436InterfaceId(sffbase):
 
     sfp_type = {
         'type':
-            {'offset':0,
-             'size':1,
-             'type' : 'enum',
-             'decode' : type_of_transceiver}
+            {'offset': 0,
+             'size': 1,
+             'type': 'enum',
+             'decode': type_of_transceiver}
         }
 
     vendor_name = {
         'Vendor Name':
-            {'offset' : 0,
+            {'offset': 0,
              'size': 16,
              'type': 'str'}
         }
@@ -382,22 +382,22 @@ class sff8436InterfaceId(sffbase):
     vendor_pn = {
         'Vendor PN':
             {'offset': 0,
-             'size'  : 16,
-             'type'  : 'str'}
+             'size': 16,
+             'type': 'str'}
         }
 
     vendor_rev = {
         'Vendor Rev':
             {'offset': 0,
-             'size'  : 2,
-             'type'  : 'str'}
+             'size': 2,
+             'type': 'str'}
         }
 
     vendor_sn = {
         'Vendor SN':
             {'offset': 0,
-             'size'  : 16,
-             'type'  : 'str'}
+             'size': 16,
+             'type': 'str'}
         }
 
     def __init__(self, eeprom_raw_data=None):
@@ -976,61 +976,61 @@ class sff8436Dom(sffbase):
 # TO DO: find a way to reuse the definitions in above code, need refactor
     dom_module_temperature = {
         'Temperature':
-            {'offset':0,
-             'size':2,
+            {'offset': 0,
+             'size': 2,
              'type': 'func',
-             'decode': {'func':calc_temperature}}
+             'decode': {'func': calc_temperature}}
         }
 
     dom_module_voltage = {
         'Vcc':
-            {'offset':0,
-             'size':2,
+            {'offset': 0,
+             'size': 2,
              'type': 'func',
-             'decode': { 'func':calc_voltage}}
+             'decode': {'func': calc_voltage}}
         }
 
     dom_channel_monitor_params = {
         'RX1Power':
-            {'offset':0,
-             'size':2,
+            {'offset': 0,
+             'size': 2,
              'type': 'func',
-             'decode': { 'func':calc_rx_power}},
+             'decode': {'func': calc_rx_power}},
         'RX2Power':
-            {'offset':2,
-             'size':2,
+            {'offset': 2,
+             'size': 2,
              'type': 'func',
-             'decode': { 'func':calc_rx_power}},
+             'decode': {'func': calc_rx_power}},
         'RX3Power':
-            {'offset':4,
-             'size':2,
+            {'offset': 4,
+             'size': 2,
              'type': 'func',
-             'decode': { 'func':calc_rx_power}},
+             'decode': {'func': calc_rx_power}},
         'RX4Power':
-            {'offset':6,
-             'size':2,
+            {'offset': 6,
+             'size': 2,
              'type': 'func',
-             'decode': { 'func':calc_rx_power}},
+             'decode': {'func': calc_rx_power}},
         'TX1Bias':
-            {'offset':8,
-             'size':2,
+            {'offset': 8,
+             'size': 2,
              'type': 'func',
-             'decode': { 'func':calc_bias}},
+             'decode': {'func': calc_bias}},
         'TX2Bias':
-            {'offset':10,
-             'size':2,
+            {'offset': 10,
+             'size': 2,
              'type': 'func',
-             'decode': { 'func':calc_bias}},
+             'decode': {'func': calc_bias}},
         'TX3Bias':
-            {'offset':12,
-             'size':2,
+            {'offset': 12,
+             'size': 2,
              'type': 'func',
-             'decode': { 'func':calc_bias}},
+             'decode': {'func': calc_bias}},
         'TX4Bias':
-            {'offset':14,
-             'size':2,
+            {'offset': 14,
+             'size': 2,
              'type': 'func',
-             'decode': { 'func':calc_bias}}
+             'decode': {'func': calc_bias}}
         }
 
     def __init__(self, eeprom_raw_data=None, calibration_type=1):

--- a/sonic_sfp/sff8472.py
+++ b/sonic_sfp/sff8472.py
@@ -345,7 +345,7 @@ class sff8472InterfaceId(sffbase):
                  'size' : 16,
                  'type' : 'str'},
             'VendorOUI':
-                {'offset':20,
+                {'offset':37,
                  'size':3,
                  'type' : 'str'},
             'VendorPN':
@@ -425,6 +425,43 @@ class sff8472InterfaceId(sffbase):
                 'size':8,
                 'type': 'date'}}
 
+# Parser for specific values that interested by SNMP
+    sfp_type = {
+        'type':
+            {'offset':0,
+             'size':1,
+             'type':'enum',
+             'decode':type_of_transceiver}
+        }
+
+    vendor_name = {
+        'Vendor Name':
+            {'offset': 0,
+             'size':16,
+             'type':'str'}
+        }
+
+    vendor_pn = {
+        'Vendor PN':
+            {'offset': 0,
+             'size': 16,
+             'type':'str'}
+        }
+
+    vendor_rev = {
+        'Vendor Rev':
+            {'offset': 0,
+             'size': 4,
+             'type': 'str'}
+        }
+
+    vendor_sn = {
+        'Vendor SN':
+                {'offset': 0,
+                 'size': 16,
+                 'type':'str'}
+        }
+
     # Returns calibration type
     def _get_calibration_type(self, eeprom_data):
         try:
@@ -452,6 +489,22 @@ class sff8472InterfaceId(sffbase):
     def parse(self, eeprom_raw_data, start_pos):
         return sffbase.parse(self, self.interface_id, eeprom_raw_data, start_pos)
 
+#new parser functions for specific values that interested by SNMP
+    def parse_sfp_type(self, type_raw_data, start_pos):
+        return sffbase.parse(self, self.sfp_type, type_raw_data, start_pos)
+
+    def parse_vendor_name(self, name_raw_data, start_pos):
+        return sffbase.parse(self, self.vendor_name, name_raw_data, start_pos)
+
+    def parse_vendor_rev(self, rev_raw_data, start_pos):
+        return sffbase.parse(self, self.vendor_rev, rev_raw_data, start_pos)
+
+    def parse_vendor_pn(self, pn_raw_data, start_pos):
+        return sffbase.parse(self, self.vendor_pn, pn_raw_data, start_pos)
+
+    def parse_vendor_sn(self, sn_raw_data, start_pos):
+        return sffbase.parse(self, self.vendor_sn, sn_raw_data, start_pos)
+
     def dump_pretty(self):
         if self.interface_data == None:
             print('Object not initialized, nothing to print')
@@ -466,7 +519,6 @@ class sff8472InterfaceId(sffbase):
 
     def get_data_pretty(self):
         return sffbase.get_data_pretty(self, self.interface_data)
-
 
 class sff8472Dom(sffbase):
     """Parser and interpretor for Diagnostics data fields at address A2h"""
@@ -683,7 +735,6 @@ class sff8472Dom(sffbase):
                 retval = str(err)
 
         return retval
-
 
     def calc_rx_power(self, eeprom_data, offset, size):
         try:
@@ -1025,6 +1076,40 @@ class sff8472Dom(sffbase):
              'type' : 'nested',
              'decode':dom_warning_flags}}
 
+# parsers for specific values that interested by SNMP
+    dom_module_temperature = {
+        'Temperature':
+            {'offset':0,
+             'size':2,
+             'type':'func',
+             'decode':{'func':calc_temperature}}
+        }
+
+    dom_module_voltage = {
+        'Vcc':
+            {'offset':0,
+             'size':2,
+             'type':'func',
+             'decode':{'func':calc_voltage}}
+        }
+
+    dom_channel_monitor_params = {
+        'TXBias':
+            {'offset':0,
+             'size':2,
+             'type':'func',
+             'decode':{'func':calc_bias}},
+        'TXPower':
+            {'offset':2,
+             'size':2,
+             'type':'func',
+             'decode': {'func':calc_tx_power}},
+        'RXPower':
+            {'offset':4,
+             'size':2,
+             'type':'func',
+             'decode': {'func':calc_rx_power}}
+        }
 
     def __init__(self, eeprom_raw_data=None, calibration_type=0):
         self._calibration_type = calibration_type
@@ -1037,6 +1122,18 @@ class sff8472Dom(sffbase):
     def parse(self, eeprom_raw_data, start_pos):
         return sffbase.parse(self, self.dom_map, eeprom_raw_data, start_pos)
 
+# parser functions for specific values interested by SNMP
+    def parse_temperature(self, eeprom_raw_data, start_pos):
+        return sffbase.parse(self, self.dom_module_temperature, eeprom_raw_data,
+                    start_pos)
+
+    def parse_voltage(self, eeprom_raw_data, start_pos):
+        return sffbase.parse(self, self.dom_module_voltage, eeprom_raw_data,
+                    start_pos)
+
+    def parse_channel_monitor_params(self, eeprom_raw_data, start_pos):
+        return sffbase.parse(self, self.dom_channel_monitor_params, eeprom_raw_data,
+                    start_pos)
 
     def dump_pretty(self):
         if self.dom_data == None:

--- a/sonic_sfp/sff8472.py
+++ b/sonic_sfp/sff8472.py
@@ -428,24 +428,24 @@ class sff8472InterfaceId(sffbase):
 # Parser for specific values that interested by SNMP
     sfp_type = {
         'type':
-            {'offset':0,
-             'size':1,
-             'type':'enum',
-             'decode':type_of_transceiver}
+            {'offset': 0,
+             'size': 1,
+             'type': 'enum',
+             'decode': type_of_transceiver}
         }
 
     vendor_name = {
         'Vendor Name':
             {'offset': 0,
-             'size':16,
-             'type':'str'}
+             'size': 16,
+             'type': 'str'}
         }
 
     vendor_pn = {
         'Vendor PN':
             {'offset': 0,
              'size': 16,
-             'type':'str'}
+             'type': 'str'}
         }
 
     vendor_rev = {
@@ -459,7 +459,7 @@ class sff8472InterfaceId(sffbase):
         'Vendor SN':
                 {'offset': 0,
                  'size': 16,
-                 'type':'str'}
+                 'type': 'str'}
         }
 
     # Returns calibration type
@@ -1079,36 +1079,36 @@ class sff8472Dom(sffbase):
 # parsers for specific values that interested by SNMP
     dom_module_temperature = {
         'Temperature':
-            {'offset':0,
-             'size':2,
-             'type':'func',
-             'decode':{'func':calc_temperature}}
+            {'offset': 0,
+             'size': 2,
+             'type': 'func',
+             'decode': {'func': calc_temperature}}
         }
 
     dom_module_voltage = {
         'Vcc':
-            {'offset':0,
-             'size':2,
-             'type':'func',
-             'decode':{'func':calc_voltage}}
+            {'offset': 0,
+             'size': 2,
+             'type': 'func',
+             'decode': {'func':calc_voltage}}
         }
 
     dom_channel_monitor_params = {
         'TXBias':
-            {'offset':0,
-             'size':2,
-             'type':'func',
-             'decode':{'func':calc_bias}},
+            {'offset': 0,
+             'size': 2,
+             'type': 'func',
+             'decode': {'func': calc_bias}},
         'TXPower':
-            {'offset':2,
-             'size':2,
-             'type':'func',
-             'decode': {'func':calc_tx_power}},
+            {'offset': 2,
+             'size': 2,
+             'type': 'func',
+             'decode': {'func': calc_tx_power}},
         'RXPower':
-            {'offset':4,
-             'size':2,
-             'type':'func',
-             'decode': {'func':calc_rx_power}}
+            {'offset': 4,
+             'size': 2,
+             'type': 'func',
+             'decode': {'func': calc_rx_power}}
         }
 
     def __init__(self, eeprom_raw_data=None, calibration_type=0):

--- a/sonic_sfp/sfputilbase.py
+++ b/sonic_sfp/sfputilbase.py
@@ -777,13 +777,13 @@ class SfpUtilBase(object):
                 return None
 
             transceiver_dom_info_dict['rx1power'] = dom_channel_monitor_data['data']['RXPower']['value']
-            transceiver_dom_info_dict['rx2power'] = ''
-            transceiver_dom_info_dict['rx3power'] = ''
-            transceiver_dom_info_dict['rx4power'] = ''
+            transceiver_dom_info_dict['rx2power'] = 'N/A'
+            transceiver_dom_info_dict['rx3power'] = 'N/A'
+            transceiver_dom_info_dict['rx4power'] = 'N/A'
             transceiver_dom_info_dict['tx1bias'] = dom_channel_monitor_data['data']['TXBias']['value']
-            transceiver_dom_info_dict['tx2bias'] = ''
-            transceiver_dom_info_dict['tx3bias'] = ''
-            transceiver_dom_info_dict['tx4bias'] = ''
+            transceiver_dom_info_dict['tx2bias'] = 'N/A'
+            transceiver_dom_info_dict['tx3bias'] = 'N/A'
+            transceiver_dom_info_dict['tx4bias'] = 'N/A'
 
         try:
             sysfsfile_eeprom.close()

--- a/sonic_sfp/sfputilbase.py
+++ b/sonic_sfp/sfputilbase.py
@@ -835,5 +835,5 @@ class SfpUtilBase(object):
         :returns: Boolean, True if call successful, False if not;
         dict for pysical interface number and the SFP status,
         status='1' represent plug in, '0' represent plug out like {'0': '1', '31':'0'}
-    """
+        """
         return

--- a/sonic_sfp/sfputilbase.py
+++ b/sonic_sfp/sfputilbase.py
@@ -725,9 +725,9 @@ class SfpUtilBase(object):
                 return None
 
             # QSFP capability byte parse, through this byte can know whether it support tx_power or not.
-            # TODO: in the future when decided to migarate to support SFF-8636 instead of SFF-8436, 
+            # TODO: in the future when decided to migrate to support SFF-8636 instead of SFF-8436,
             # need to add more code for determining the capability and version compliance
-            # in SFF-8636 dom capability definitions evolving with the version.
+            # in SFF-8636 dom capability definitions evolving with the versions.
             qsfp_dom_capability_raw = self._read_eeprom_specific_bytes(sysfsfile_eeprom, (offset_xcvr + XCVR_DOM_CAPABILITY_OFFSET), XCVR_DOM_CAPABILITY_WIDTH)
             if qsfp_dom_capability_raw is not None:
                 qspf_dom_capability_data = sfpi_obj.parse_qsfp_dom_capability(qsfp_dom_capability_raw, 0)

--- a/sonic_sfp/sfputilbase.py
+++ b/sonic_sfp/sfputilbase.py
@@ -732,6 +732,12 @@ class SfpUtilBase(object):
             else:
                 return None
 
+            try:
+                sysfsfile_eeprom.close()
+            except IOError:
+                print("Error: closing sysfs file %s" % file_path)
+                return None
+
             transceiver_dom_info_dict['rx1power'] = dom_channel_monitor_data['data']['RX1Power']['value']
             transceiver_dom_info_dict['rx2power'] = dom_channel_monitor_data['data']['RX2Power']['value']
             transceiver_dom_info_dict['rx3power'] = dom_channel_monitor_data['data']['RX3Power']['value']
@@ -775,6 +781,12 @@ class SfpUtilBase(object):
             else:
                 return None
 
+            try:
+                sysfsfile_eeprom.close()
+            except IOError:
+                print("Error: closing sysfs file %s" % file_path)
+                return None
+
             transceiver_dom_info_dict['rx1power'] = dom_channel_monitor_data['data']['RXPower']['value']
             transceiver_dom_info_dict['rx2power'] = 'N/A'
             transceiver_dom_info_dict['rx3power'] = 'N/A'
@@ -783,12 +795,6 @@ class SfpUtilBase(object):
             transceiver_dom_info_dict['tx2bias'] = 'N/A'
             transceiver_dom_info_dict['tx3bias'] = 'N/A'
             transceiver_dom_info_dict['tx4bias'] = 'N/A'
-
-        try:
-            sysfsfile_eeprom.close()
-        except IOError:
-            print("Error: closing sysfs file %s" % file_path)
-            return None
 
         transceiver_dom_info_dict['temperature'] = dom_temperature_data['data']['Temperature']['value']
         transceiver_dom_info_dict['voltage'] = dom_voltage_data['data']['Vcc']['value']

--- a/sonic_sfp/sfputilbase.py
+++ b/sonic_sfp/sfputilbase.py
@@ -689,7 +689,7 @@ class SfpUtilBase(object):
         try:
             sysfsfile_eeprom.close()
         except IOError:
-            print("Error: closing sysfs file %s" % file_path")
+            print("Error: closing sysfs file %s" % file_path)
             return None
 
         transceiver_info_dict['type'] = sfp_type_data['data']['type']['value']

--- a/sonic_sfp/sfputilbase.py
+++ b/sonic_sfp/sfputilbase.py
@@ -310,14 +310,15 @@ class SfpUtilBase(object):
 
         # Read the porttab file and generate dicts
         # with mapping for future reference.
-        # XXX: move the porttab
-        # parsing stuff to a separate module, or reuse
-        # if something already exists
+        #
+        # TODO: Refactor this to use the portconfig.py module that now
+        # exists as part of the sonic-config-engine package.
+        title = []
         for line in f:
             line.strip()
-            title = []
             if re.search("^#", line) is not None:
                 # The current format is: # name lanes alias index speed
+                # Where the ordering of the columns can vary
                 title = line.split()[1:]
                 continue
 
@@ -682,8 +683,8 @@ class SfpUtilBase(object):
 
         try:
             sysfsfile_eeprom.close()
-        except:
-            print("Error: file close failed")
+        except IOError:
+            print("Error: closing sysfs file %s" % file_path")
             return None
 
         transceiver_info_dict['type'] = sfp_type_data['data']['type']['value']
@@ -692,9 +693,7 @@ class SfpUtilBase(object):
         transceiver_info_dict['hardwarerev'] = sfp_vendor_rev_data['data']['Vendor Rev']['value']
         transceiver_info_dict['serialnum'] = sfp_vendor_sn_data['data']['Vendor SN']['value']
 
-        #print("transceiver info succcessfully fetched")
         return transceiver_info_dict
-        #return sfp_type_data, sfp_vendor_name_data, sfp_vendor_pn_data, sfp_vendor_rev_data, sfp_vendor_sn_data
 
     def get_transceiver_dom_info_dict(self, port_num):
         transceiver_dom_info_dict = {}
@@ -787,14 +786,14 @@ class SfpUtilBase(object):
 
         try:
             sysfsfile_eeprom.close()
-        except:
+        except IOError:
+            print("Error: closing sysfs file %s" % file_path)
             return None
 
         transceiver_dom_info_dict['temperature'] = dom_temperature_data['data']['Temperature']['value']
         transceiver_dom_info_dict['voltage'] = dom_voltage_data['data']['Vcc']['value']
 
         return transceiver_dom_info_dict
-        #return dom_temperature_data, dom_voltage_data, dom_channel_monitor_data
 
     @abc.abstractmethod
     def get_presence(self, port_num):
@@ -833,8 +832,8 @@ class SfpUtilBase(object):
     def get_transceiver_change_event(self, timeout=0):
         """
         :param timeout
-		:returns: Boolean, True if call successful, False if not;
+        :returns: Boolean, True if call successful, False if not;
         dict for pysical interface number and the SFP status,
-		status='1' represent plug in, '0' represent plug out like {'0': '1', '31':'0'}
+        status='1' represent plug in, '0' represent plug out like {'0': '1', '31':'0'}
     """
         return


### PR DESCRIPTION
    [sfputilbase]: enhance the sfputilbase for transceiver monitoring
    
    [List of changes]
    
    * add ability to only read and parse specific bytes from eeprom
    * add two API to read the transceiver info and dom info which intrested by SNMP
    * add a new API definiton: get_transceiver_change_event
    * fix a bug: wrong 'VendorOUI' offset for sff8472
    
        modified:   sff8436.py
        modified:   sff8472.py
        modified:   sfputilbase.py
    
    Signed-off-by Liu Kebo kebol@mellanox.com