### PR TITLE
[sonic_eeprom] If reading from what appears to be a corrupt cache file, delete file and read directly from EEPROM

### DIFF
--- a/sonic_eeprom/eeprom_base.py
+++ b/sonic_eeprom/eeprom_base.py
@@ -232,18 +232,22 @@ class EepromDecoder(object):
         F = self.open_eeprom()
         F.seek(self.s + offset)
         o = F.read(byteCount)
+
+        # If we read from the cache file and the byte count isn't what we
+        # expect, the file may be corrupt. Delete it and try again, this
+        # time reading from the actual EEPROM.
+        if len(o) != byteCount and not self.cache_update_needed:
+            os.remove(self.cache_name)
+            self.cache_update_needed = True
+            F.close()
+            F = self.open_eeprom()
+            F.seek(self.s + offset)
+            o = F.read(byteCount)
+
         if len(o) != byteCount:
-            # If we read from the cache file, it may be corrupt. Delete it
-            # and try again, this time reading from the actual EEPROM.
-            if not self.cache_update_needed:
-                os.remove(self.cache_name)
-                self.cache_update_needed = True
-                F.close()
-                return self.read_eeprom_bytes(byteCount, offset)
-            else:
-                raise RuntimeError("Expected to read %d bytes from %s, " \
-                                   %(byteCount, self.p) +
-                                   "but only read %d" %(len(o)))
+            raise RuntimeError("Expected to read %d bytes from %s, "
+                               % (byteCount, self.p) +
+                               "but only read %d" % (len(o)))
         F.close()
         return o
 


### PR DESCRIPTION
Before this PR, if a corrupt cache file exists, decode-syseeprom will fail indefinitely until the file is manually deleted.