### PR TITLE
[sff8472] Fix incorrect VendorOUI decode type.

### DIFF
--- a/sonic_sfp/sff8472.py
+++ b/sonic_sfp/sff8472.py
@@ -347,7 +347,7 @@ class sff8472InterfaceId(sffbase):
             'VendorOUI':
                 {'offset':37,
                  'size':3,
-                 'type' : 'str'},
+                 'type' : 'hex'},
             'VendorPN':
                 {'offset':40,
                  'size':16,


### PR DESCRIPTION
The VendorOUI should decode as hex.