### PR TITLE
[xcvrd]fix xcvrd will core on ingrasys s9130-32x

### DIFF
--- a/sonic_sfp/sff8436.py
+++ b/sonic_sfp/sff8436.py
@@ -197,10 +197,47 @@ class sff8436InterfaceId(sffbase):
             '0a': 'X2',
             '0b': 'DWDM-SFP',
             '0c': 'QSFP',
-            '0d': 'QSFP+'
+            '0d': 'QSFP+',
+            '11': 'QSFP28'
             }
 
-    ext_type_of_transceiver = {}
+    ext_type_of_transceiver = {
+            '00': 'Power Class 1(1.5W max)',
+            '04': 'Power Class 1(1.5W max), CDR present in Tx',
+            '08': 'Power Class 1(1.5W max), CDR present in Rx',
+            '0c': 'Power Class 1(1.5W max), CDR present in Rx Tx',
+            '10': 'Power Class 1(1.5W max), CLEI present',
+            '14': 'Power Class 1(1.5W max), CLEI present, CDR present in Tx',
+            '18': 'Power Class 1(1.5W max), CLEI present, CDR present in Rx',
+            '1c': 'Power Class 1(1.5W max), CLEI present, CDR present in Rx Tx',
+
+            '40': 'Power Class 2(2.0W max)',
+            '44': 'Power Class 2(2.0W max), CDR present in Rx',
+            '48': 'Power Class 2(2.0W max), CDR present in Tx',
+            '4c': 'Power Class 2(2.0W max), CDR present in Rx Tx',
+            '50': 'Power Class 2(2.0W max), CLEI present',
+            '54': 'Power Class 2(2.0W max), CLEI present, CDR present in Rx',
+            '58': 'Power Class 2(2.0W max), CLEI present, CDR present in Tx',
+            '5c': 'Power Class 2(2.0W max), CLEI present, CDR present in Rx Tx',
+
+            '80': 'Power Class 3(2.5W max)',
+            '84': 'Power Class 3(2.5W max), CDR present in Rx',
+            '88': 'Power Class 3(2.5W max), CDR present in Tx',
+            '8c': 'Power Class 3(2.5W max), CDR present in Rx Tx',
+            '90': 'Power Class 3(2.5W max), CLEI present',
+            '94': 'Power Class 3(2.5W max), CLEI present, CDR present in Rx',
+            '98': 'Power Class 3(2.5W max), CLEI present, CDR present in Tx',
+            '9c': 'Power Class 3(2.5W max), CLEI present, CDR present in Rx Tx',
+
+            'c0': 'Power Class 4(3.5W max)',
+            'c4': 'Power Class 4(3.5W max), CDR present in Rx',
+            'c8': 'Power Class 4(3.5W max), CDR present in Tx',
+            'cc': 'Power Class 4(3.5W max), CDR present in Rx Tx',
+            'd0': 'Power Class 4(3.5W max), CLEI present',
+            'd4': 'Power Class 4(3.5W max), CLEI present, CDR present in Rx',
+            'd8': 'Power Class 4(3.5W max), CLEI present, CDR present in Tx',
+            'dc': 'Power Class 4(3.5W max), CLEI present, CDR present in Rx Tx'
+            }
 
     connector = {
             '00': 'Unknown or unspecified',
@@ -215,7 +252,8 @@ class sff8436InterfaceId(sffbase):
             '09': 'MU',
             '0a': 'SG',
             '0b': 'Optical Pigtail',
-            '0C': 'MPO',
+            '0c': 'MPOx12',
+            '0d': 'MPOx16',
             '20': 'HSSDC II',
             '21': 'Copper pigtail',
             '22': 'RJ45',
@@ -229,7 +267,8 @@ class sff8436InterfaceId(sffbase):
             '03': 'NRZ',
             '04': 'SONET Scrambled',
             '05': '64B66B',
-            '06': 'Manchester'
+            '06': 'Manchester',
+            '07': '256B257B'
             }
 
     rate_identifier = {'00':'QSFP+ Rate Select Version 1'}


### PR DESCRIPTION
below is the core calling stack, so I changed the reading schema, reading once instead of reading per item,  no core again
<pre>
    Sep 27 07:42:46.062440 S9130-Core WARNING kernel: [   86.937169] general protection fault: 0000 [#1] SMP
    Sep 27 07:42:46.062453 S9130-Core WARNING kernel: [   86.942722] Modules linked in: 8021q garp mrp optoe sff_8436_eeprom ingrasys_s9130_32x_psu(O) jc42 lm75 w83795 coretemp gpio_pca953x eeprom_mb(O) i2c_mux_pca954x i2c_mux i2c_dev i2c_i801 bridge stp llc nps_netif(O) nps_dev(O) x86_pkg_temp_thermal kvm_intel kvm crc32_pclmul aesni_intel iTCO_wdt aes_x86_64 iTCO_vendor_support lrw evdev gf128mul mxm_wmi glue_helper ablk_helper cryptd pcspkr ip6table_filter tpm_tis tpm ip6_tables xt_conntrack iptable_filter ipt_MASQUERADE xt_addrtype lpc_ich mfd_core processor i2c_core iptable_nat thermal_sys nf_conntrack_ipv4 shpchp nf_defrag_ipv4 wmi button nf_nat_ipv4 nf_nat nf_conntrack ip_tables x_tables autofs4 loop ext4 crc16 mbcache jbd2 nls_utf8 nls_cp437 vfat fat aufs(C) squashfs sg sd_mod crc_t10dif crct10dif_generic crct10dif_pclmul crct10dif_common xhci_hcd ixgbe(O) crc32c_intel ahci igb(O) libahci libata dca vxlan scsi_mod usbcore ptp usb_common pps_core [last unloaded: coretemp]
    Sep 27 07:42:46.062454 S9130-Core WARNING kernel: [   87.034497] CPU: 0 PID: 2503 Comm: xcvrd Tainted: G         C O  3.16.0-5-amd64 #1 Debian 3.16.51-3+deb8u1
    Sep 27 07:42:46.062455 S9130-Core WARNING kernel: [   87.045273] Hardware name: Default string Default string/Default string, BIOS 5.11 08/30/2017
    Sep 27 07:42:46.062459 S9130-Core WARNING kernel: [   87.054789] task: ffff88046916b310 ti: ffff88046b8e0000 task.ti: ffff88046b8e0000
    Sep 27 07:42:46.062459 S9130-Core WARNING kernel: [   87.063132] RIP: 0010:[<ffffffffa031c48f>]  [<ffffffffa031c48f>] i2c_smbus_read_i2c_block_data+0x3f/0xa0 [i2c_core]
    Sep 27 07:42:46.062460 S9130-Core WARNING kernel: [   87.074800] RSP: 0018:ffff88046b8e3d68  EFLAGS: 00010246
    Sep 27 07:42:46.062460 S9130-Core WARNING kernel: [   87.080728] RAX: 0000000000000020 RBX: ffff88046b8e3d76 RCX: 0000000000000001
    Sep 27 07:42:46.062461 S9130-Core WARNING kernel: [   87.088695] RDX: 0000000000000020 RSI: 000000000000009c RDI: 0000ff00f0000711
    Sep 27 07:42:46.062461 S9130-Core WARNING kernel: [   87.096661] RBP: ffff8800366f8f3c R08: 000000000000009c R09: 0000000000000008
    Sep 27 07:42:46.062462 S9130-Core WARNING kernel: [   87.104624] R10: 0000000000000020 R11: 0000000000000005 R12: 00000000ffff3003
    Sep 27 07:42:46.062464 S9130-Core WARNING kernel: [   87.112587] R13: 0000ff00f0000711 R14: ffff8800366f8c00 R15: 00000000ffff300a
    Sep 27 07:42:46.062465 S9130-Core WARNING kernel: [   87.120551] FS:  00007fbe95bcb700(0000) GS:ffff88047fc00000(0000) knlGS:0000000000000000
    Sep 27 07:42:46.062466 S9130-Core WARNING kernel: [   87.129581] CS:  0010 DS: 0000 ES: 0000 CR0: 0000000080050033
    Sep 27 07:42:46.062466 S9130-Core WARNING kernel: [   87.135991] CR2: 000000000176da40 CR3: 0000000468b50000 CR4: 0000000000360770
    Sep 27 07:42:46.062467 S9130-Core WARNING kernel: [   87.143947] DR0: 0000000000000000 DR1: 0000000000000000 DR2: 0000000000000000
    Sep 27 07:42:46.062467 S9130-Core WARNING kernel: [   87.151910] DR3: 0000000000000000 DR6: 00000000fffe0ff0 DR7: 0000000000000400
    Sep 27 07:42:46.062468 S9130-Core WARNING kernel: [   87.159874] Stack:
    Sep 27 07:42:46.062474 S9130-Core WARNING kernel: [   87.162113]  ffff88046b8e3d76 0020000000000000 00f0000711000000 00000000000000ff
    Sep 27 07:42:46.062475 S9130-Core WARNING kernel: [   87.170371]  0000000000000000 ff788100008f2600 00000000035bbb2a 0000000000000020
    Sep 27 07:42:46.062475 S9130-Core WARNING kernel: [   87.178644]  ffff88046b8e3ed8 00000000ffff3003 ffffffffa045895e 0000000000000002
    Sep 27 07:42:46.062476 S9130-Core WARNING kernel: [   87.186918] Call Trace:
    Sep 27 07:42:46.062477 S9130-Core WARNING kernel: [   87.189645]  [<ffffffffa045895e>] ? sff_8436_read_write+0x55e/0xcf0 [sff_8436_eeprom]
    Sep 27 07:42:46.062477 S9130-Core WARNING kernel: [   87.198390]  [<ffffffff8121fb65>] ? kernfs_fop_read+0x95/0x150
    Sep 27 07:42:46.062480 S9130-Core WARNING kernel: [   87.204900]  [<ffffffff811aec83>] ? vfs_read+0x93/0x170
    Sep 27 07:42:46.062480 S9130-Core WARNING kernel: [   87.210730]  [<ffffffff811af8b2>] ? SyS_read+0x42/0xa0
    Sep 27 07:42:46.062481 S9130-Core WARNING kernel: [   87.216465]  [<ffffffff811ae96e>] ? SyS_lseek+0x7e/0xa0
    Sep 27 07:42:46.062482 S9130-Core WARNING kernel: [   87.222298]  [<ffffffff81525c00>] ? system_call_fast_compare_end+0x10/0x15
    Sep 27 07:42:46.062482 S9130-Core WARNING kernel: [   87.229969] Code: cd b9 01 00 00 00 53 48 83 ec 38 65 48 8b 04 25 28 00 00 00 48 89 44 24 30 31 c0 80 fa 20 b8 20 00 00 00 48 8d 5c 24 0e 0f 46 c2 <0f> b7 17 88 44 24 0e 0f b7 47 02 48 8b 7f 18 48 89 1c 24 89 c6
    Sep 27 07:42:46.062484 S9130-Core WARNING kernel: [   87.260360]  RSP <ffff88046b8e3d68>
    Sep 27 07:42:46.062494 S9130-Core WARNING kernel: [   87.264284] ---[ end trace 7b8c245201b18756 ]---
    Sep 27 07:42:46.585287 S9130-Core INFO swss#supervisord: start.sh vlanmgrd: started
    Sep 27 07:42:46.596847 S9130-Core WARNING kernel: [   87.793534] NOHZ: local_softirq_pending 08
</pre>

After modification, the trans info is correctly loaded to redis db 6

<pre>
admin@S9130-Leaf-Right:~$ redis-cli
127.0.0.1:6379> select 6
OK
127.0.0.1:6379[6]> keys *TRANS*
1) "TRANSCEIVER_DOM_SENSOR|Ethernet29"
2) "TRANSCEIVER_INFO|Ethernet29"
3) "TRANSCEIVER_DOM_SENSOR|Ethernet30"
4) "TRANSCEIVER_DOM_SENSOR|Ethernet2"
5) "TRANSCEIVER_INFO|Ethernet2"
6) "TRANSCEIVER_DOM_SENSOR|Ethernet1"
7) "TRANSCEIVER_INFO|Ethernet1"
8) "TRANSCEIVER_INFO|Ethernet30"
127.0.0.1:6379[6]> hgetall TRANSCEIVER_INFO|Ethernet29
 1) "type"
 2) "QSFP+"
 3) "hardwarerev"
 4) "A1"
 5) "serialnum"
 6) "GE1704171119"
 7) "manufacturename"
 8) "Gigalight"
 9) "modelname"
10) "GQS-MDO400-005C"
127.0.0.1:6379[6]> hgetall TRANSCEIVER_DOM_SENSOR|Ethernet1
 1) "temperature"
 2) "36.9766"
 3) "voltage"
 4) "3.3128"
 5) "rx1power"
 6) "0.1949"
 7) "rx2power"
 8) "0.3563"
 9) "rx3power"
10) "0.4305"
11) "rx4power"
12) "0.3957"
13) "tx1bias"
14) "7.3000"
15) "tx2bias"
16) "7.3000"
17) "tx3bias"
18) "7.3000"
19) "tx4bias"
20) "7.3000"
21) "tx1power"
22) "N/A"
23) "tx2power"
24) "N/A"
25) "tx3power"
26) "N/A"
27) "tx4power"
28) "N/A"
</pre>