### PR TITLE
[sfp_util] open eeprom files with buffering disabled

### DIFF
--- a/sonic_sfp/sfputilbase.py
+++ b/sonic_sfp/sfputilbase.py
@@ -198,7 +198,7 @@ class SfpUtilBase(object):
             return False
         else:
             try:
-                sysfsfile = open(sysfs_sfp_i2c_client_eeprompath, "rb")
+                sysfsfile = open(sysfs_sfp_i2c_client_eeprompath, mode="rb", buffering=0)
                 sysfsfile.seek(offset)
                 sysfsfile.read(1)
             except IOError:
@@ -275,7 +275,7 @@ class SfpUtilBase(object):
             return None
 
         try:
-            sysfsfile_eeprom = open(sysfs_sfp_i2c_client_eeprom_path, "rb")
+            sysfsfile_eeprom = open(sysfs_sfp_i2c_client_eeprom_path, mode="rb", buffering=0)
         except IOError:
             print("Error: reading sysfs file %s" % sysfs_sfp_i2c_client_eeprom_path)
             return None
@@ -646,7 +646,7 @@ class SfpUtilBase(object):
             return None
 
         try:
-            sysfsfile_eeprom = open(file_path, "rb")
+            sysfsfile_eeprom = open(file_path, mode="rb", buffering=0)
         except IOError:
             print("Error: reading sysfs file %s" % file_path)
             return None
@@ -711,7 +711,7 @@ class SfpUtilBase(object):
                 return None
 
             try:
-                sysfsfile_eeprom = open(file_path, "rb")
+                sysfsfile_eeprom = open(file_path, mode="rb", buffering=0)
             except IOError:
                 print("Error: reading sysfs file %s" % file_path)
                 return None
@@ -807,7 +807,7 @@ class SfpUtilBase(object):
                 return None
 
             try:
-                sysfsfile_eeprom = open(file_path, "rb")
+                sysfsfile_eeprom = open(file_path, mode="rb", buffering=0)
             except IOError:
                 print("Error: reading sysfs file %s" % file_path)
                 return None

--- a/sonic_sfp/sfputilbase.py
+++ b/sonic_sfp/sfputilbase.py
@@ -198,9 +198,9 @@ class SfpUtilBase(object):
             return False
         else:
             try:
-                sysfsfile = open(sysfs_sfp_i2c_client_eeprompath, mode="rb", buffering=0)
-                sysfsfile.seek(offset)
-                sysfsfile.read(1)
+                with open(sysfs_sfp_i2c_client_eeprompath, mode="rb", buffering=0) as sysfsfile:
+                    sysfsfile.seek(offset)
+                    sysfsfile.read(1)
             except IOError:
                 return False
             except:


### PR DESCRIPTION
Buffering will cause read to read more than requested. For slow files
like SFP EEPROM, we want to read exactly what we asked for.

Signed-off-by: Ying Xie <ying.xie@microsoft.com>