### PR TITLE
[sonic_sfp] Extend sfpbase to get more info from SFP eeprom for xcvrd

### DIFF
--- a/sonic_sfp/sff8436.py
+++ b/sonic_sfp/sff8436.py
@@ -493,6 +493,9 @@ class sff8436InterfaceId(sffbase):
 
     def parse_vendor_date(self, sn_raw_data, start_pos):
         return sffbase.parse(self, self.vendor_date, sn_raw_data, start_pos)
+    
+    def parse_vendor_oui(self, sn_raw_data, start_pos):
+        return sffbase.parse(self, self.vendor_oui, sn_raw_data, start_pos)
 
     def parse_qsfp_dom_capability(self, sn_raw_data, start_pos):
         return sffbase.parse(self, self.qsfp_dom_capability, sn_raw_data, start_pos)

--- a/sonic_sfp/sff8436.py
+++ b/sonic_sfp/sff8436.py
@@ -363,15 +363,62 @@ class sff8436InterfaceId(sffbase):
                  'size'  : 1,
                  'type'  : 'bitmap',
                  'decode': {}}}
-
-    sfp_type = {
-        'type':
-            {'offset': 0,
-             'size': 1,
-             'type': 'enum',
-             'decode': type_of_transceiver}
-        }
-
+    
+    sfp_info_bulk = {'type':
+                {'offset':0,
+                 'size':1,
+                 'type' : 'enum',
+                 'decode' : type_of_transceiver},
+             'Extended Identifier':
+                {'offset':1,
+                 'size':1,
+                 'type' : 'enum',
+                 'decode': ext_type_of_transceiver},
+             'Connector':
+                {'offset':2,
+                 'size':1,
+                 'type' : 'enum',
+                 'decode': connector},
+            'Specification compliance':
+                {'offset' : 3,
+                 'type' : 'nested',
+                 'decode' : specification_compliance},
+            'EncodingCodes':
+                {'offset':11,
+                 'size':1,
+                 'type' : 'enum',
+                 'decode' : encoding_codes},
+            'Nominal Bit Rate(100Mbs)':
+                {'offset': 12,
+                 'size':1,
+                 'type':'int'},
+            'RateIdentifier':
+                {'offset':13,
+                 'size':1,
+                 'type' : 'enum',
+                 'decode' : rate_identifier},
+            'Length(km)':
+                {'offset':14,
+                 'size':1,
+                 'type':'int'},
+            'Length OM3(2m)':
+                {'offset':15,
+                 'size':1,
+                 'type':'int'},
+            'Length OM2(m)':
+                {'offset':16,
+                'size':1,
+                 'type':'int'},
+            'Length OM1(m)':
+                {'offset':17,
+                'size':1,
+                 'type':'int'},
+            'Length Cable Assembly(m)':
+                {'offset':18,
+                'size':1,
+                 'type':'int'}
+    }
+    
     vendor_name = {
         'Vendor Name':
             {'offset': 0,
@@ -400,6 +447,20 @@ class sff8436InterfaceId(sffbase):
              'type': 'str'}
         }
 
+    vendor_oui = {
+        'Vendor OUI':
+                {'offset':0,
+                 'size':3,
+                 'type' : 'hex'}
+        }
+    
+    vendor_date = {
+        'VendorDataCode(YYYY-MM-DD Lot)':
+                {'offset':0,
+                'size':8,
+                'type': 'date'}
+        }
+
     qsfp_dom_capability = {
         'Tx_power_support':
             {'offset': 0,
@@ -418,7 +479,6 @@ class sff8436InterfaceId(sffbase):
              'bit': 5,
              'type': 'bitvalue'}
         }
-    
 
     def __init__(self, eeprom_raw_data=None):
         self.interface_data = None
@@ -433,8 +493,8 @@ class sff8436InterfaceId(sffbase):
     def parse(self, eeprom_raw_data, start_pos):
         return sffbase.parse(self, self.interface_id, eeprom_raw_data, start_pos)
 
-    def parse_sfp_type(self, type_raw_data, start_pos):
-        return sffbase.parse(self, self.sfp_type, type_raw_data, start_pos)
+    def parse_sfp_info_bulk(self, type_raw_data, start_pos):
+        return sffbase.parse(self, self.sfp_info_bulk, type_raw_data, start_pos)
 
     def parse_vendor_name(self, name_raw_data, start_pos):
         return sffbase.parse(self, self.vendor_name, name_raw_data, start_pos)
@@ -447,6 +507,9 @@ class sff8436InterfaceId(sffbase):
 
     def parse_vendor_sn(self, sn_raw_data, start_pos):
         return sffbase.parse(self, self.vendor_sn, sn_raw_data, start_pos)
+
+    def parse_vendor_date(self, sn_raw_data, start_pos):
+        return sffbase.parse(self, self.vendor_date, sn_raw_data, start_pos)
 
     def parse_qsfp_dom_capability(self, sn_raw_data, start_pos):
         return sffbase.parse(self, self.qsfp_dom_capability, sn_raw_data, start_pos)

--- a/sonic_sfp/sff8472.py
+++ b/sonic_sfp/sff8472.py
@@ -426,13 +426,65 @@ class sff8472InterfaceId(sffbase):
                 'type': 'date'}}
 
 # Parser for specific values that interested by SNMP
-    sfp_type = {
-        'type':
-            {'offset': 0,
-             'size': 1,
-             'type': 'enum',
-             'decode': type_of_transceiver}
-        }
+
+    sfp_info_bulk = {'type':
+                {'offset':0,
+                 'size':1,
+                 'type' : 'enum',
+                 'decode' : type_of_transceiver},
+             'Extended Identifier':
+                {'offset':1,
+                 'size':1,
+                 'type' : 'enum',
+                 'decode': exttypeoftransceiver},
+             'Connector':
+                {'offset':2,
+                 'size':1,
+                 'type' : 'enum',
+                 'decode': connector},
+            'Specification compliance':
+                {'offset' : 3,
+                 'type' : 'nested',
+                 'decode' : transceiver_codes},
+            'EncodingCodes':
+                {'offset':11,
+                 'size':1,
+                 'type' : 'enum',
+                 'decode' : encoding_codes},
+            'NominalSignallingRate(UnitsOf100Mbd)':
+                {'offset': 12,
+                 'size':1,
+                 'type':'int'},
+            'RateIdentifier':
+                {'offset':13,
+                 'size':1,
+                 'type' : 'enum',
+                 'decode' : rate_identifier},
+            'LengthSMFkm-UnitsOfKm':
+                {'offset':14,
+                 'size':1,
+                 'type':'int'},
+            'LengthSMF(UnitsOf100m)':
+                {'offset':15,
+                 'size':1,
+                 'type':'int'},
+            'Length50um(UnitsOf10m)':
+                {'offset':16,
+                'size':1,
+                 'type':'int'},
+            'Length62.5um(UnitsOfm)':
+                {'offset':17,
+                'size':1,
+                 'type':'int'},
+            'LengthCable(UnitsOfm)':
+                {'offset':18,
+                'size':1,
+                 'type':'int'},
+            'LengthOM3(UnitsOf10m)':
+                {'offset':19,
+                 'size':1,
+                 'type':'int'}
+    }
 
     vendor_name = {
         'Vendor Name':
@@ -457,9 +509,23 @@ class sff8472InterfaceId(sffbase):
 
     vendor_sn = {
         'Vendor SN':
-                {'offset': 0,
-                 'size': 16,
-                 'type': 'str'}
+            {'offset': 0,
+             'size': 16,
+             'type': 'str'}
+        }
+
+    vendor_oui = {
+        'Vendor OUI':
+            {'offset':0,
+             'size':3,
+             'type' : 'hex'}
+        }
+    
+    vendor_date = {
+        'VendorDataCode(YYYY-MM-DD Lot)':
+            {'offset':0,
+            'size':8,
+            'type': 'date'}
         }
 
     # Returns calibration type
@@ -490,8 +556,8 @@ class sff8472InterfaceId(sffbase):
         return sffbase.parse(self, self.interface_id, eeprom_raw_data, start_pos)
 
 #new parser functions for specific values that interested by SNMP
-    def parse_sfp_type(self, type_raw_data, start_pos):
-        return sffbase.parse(self, self.sfp_type, type_raw_data, start_pos)
+    def parse_sfp_info_bulk(self, type_raw_data, start_pos):
+        return sffbase.parse(self, self.sfp_info_bulk, type_raw_data, start_pos)
 
     def parse_vendor_name(self, name_raw_data, start_pos):
         return sffbase.parse(self, self.vendor_name, name_raw_data, start_pos)
@@ -505,6 +571,12 @@ class sff8472InterfaceId(sffbase):
     def parse_vendor_sn(self, sn_raw_data, start_pos):
         return sffbase.parse(self, self.vendor_sn, sn_raw_data, start_pos)
 
+    def parse_vendor_date(self, sn_raw_data, start_pos):
+        return sffbase.parse(self, self.vendor_date, sn_raw_data, start_pos)
+
+    def parse_vendor_oui(self, sn_raw_data, start_pos):
+        return sffbase.parse(self, self.vendor_oui, sn_raw_data, start_pos)
+    
     def dump_pretty(self):
         if self.interface_data == None:
             print('Object not initialized, nothing to print')

--- a/sonic_sfp/sfputilbase.py
+++ b/sonic_sfp/sfputilbase.py
@@ -20,10 +20,30 @@ except ImportError as e:
     raise ImportError("%s - required module not found" % str(e))
 
 # definitions of the offset and width for values in XCVR info eeprom
+XCVR_INTFACE_BULK_OFFSET = 0
+XCVR_INTFACE_BULK_WIDTH_QSFP = 20
+XCVR_INTFACE_BULK_WIDTH_SFP = 21
 XCVR_TYPE_OFFSET = 0
 XCVR_TYPE_WIDTH = 1
+XCVR_EXT_TYPE_OFFSET = 1
+XCVR_EXT_TYPE_WIDTH = 1
+XCVR_CONNECTOR_OFFSET = 2
+XCVR_CONNECTOR_WIDTH = 1
+XCVR_COMPLIANCE_CODE_OFFSET = 3
+XCVR_COMPLIANCE_CODE_WIDTH = 8
+XCVR_ENCODING_OFFSET = 11
+XCVR_ENCODING_WIDTH = 1
+XCVR_NBR_OFFSET = 12
+XCVR_NBR_WIDTH = 1
+XCVR_EXT_RATE_SEL_OFFSET = 13
+XCVR_EXT_RATE_SEL_WIDTH = 1
+XCVR_CABLE_LENGTH_OFFSET = 14
+XCVR_CABLE_LENGTH_WIDTH_QSFP = 5
+XCVR_CABLE_LENGTH_WIDTH_SFP = 6
 XCVR_VENDOR_NAME_OFFSET = 20
 XCVR_VENDOR_NAME_WIDTH = 16
+XCVR_VENDOR_OUI_OFFSET = 37
+XCVR_VENDOR_OUI_WIDTH = 3
 XCVR_VENDOR_PN_OFFSET = 40
 XCVR_VENDOR_PN_WIDTH = 16
 XCVR_HW_REV_OFFSET = 56
@@ -31,6 +51,8 @@ XCVR_HW_REV_WIDTH_QSFP = 2
 XCVR_HW_REV_WIDTH_SFP = 4
 XCVR_VENDOR_SN_OFFSET = 68
 XCVR_VENDOR_SN_WIDTH = 16
+XCVR_VENDOR_DATE_OFFSET = 84
+XCVR_VENDOR_DATE_WIDTH = 8
 XCVR_DOM_CAPABILITY_OFFSET = 92
 XCVR_DOM_CAPABILITY_WIDTH = 1
 
@@ -51,6 +73,25 @@ SFP_VLOT_OFFSET = 98
 SFP_VOLT_WIDTH = 2
 SFP_CHANNL_MON_OFFSET = 100
 SFP_CHANNL_MON_WIDTH = 6
+
+qsfp_cable_length_tup = ('Length(km)', 'Length OM3(2m)', 
+                         'Length OM2(m)', 'Length OM1(m)',
+                         'Length Cable Assembly(m)')
+
+sfp_cable_length_tup = ('LengthSMFkm-UnitsOfKm', 'LengthSMF(UnitsOf100m)',
+                        'Length50um(UnitsOf10m)', 'Length62.5um(UnitsOfm)',
+                        'LengthCable(UnitsOfm)', 'LengthOM3(UnitsOf10m)')
+
+sfp_compliance_code_tup = ('10GEthernetComplianceCode', 'InfinibandComplianceCode', 
+                            'ESCONComplianceCodes', 'SONETComplianceCodes',
+                            'EthernetComplianceCodes','FibreChannelLinkLength',
+                            'FibreChannelTechnology', 'SFP+CableTechnology',
+                            'FibreChannelTransmissionMedia','FibreChannelSpeed')
+
+qsfp_compliance_code_tup = ('10/40G Ethernet Compliance Code', 'SONET Compliance codes',
+                            'SAS/SATA compliance codes', 'Gigabit Ethernet Compliant codes',
+                            'Fibre Channel link length/Transmitter Technology',
+                            'Fibre Channel transmission media', 'Fibre Channel Speed')
 
 class SfpUtilError(Exception):
     """Base class for exceptions in this module."""
@@ -632,13 +673,31 @@ class SfpUtilBase(object):
     # Read out SFP type, vendor name, PN, REV, SN from eeprom.
     def get_transceiver_info_dict(self, port_num):
         transceiver_info_dict = {}
+        compliance_code_dict = {}
 
         if port_num in self.qsfp_ports:
             offset = 128
             vendor_rev_width = XCVR_HW_REV_WIDTH_QSFP
+            cable_length_width = XCVR_CABLE_LENGTH_WIDTH_QSFP
+            interface_info_bulk_width = XCVR_INTFACE_BULK_WIDTH_QSFP
+            sfp_type = 'QSFP'
+
+            sfpi_obj = sff8436InterfaceId()
+            if sfpi_obj is None:
+                print("Error: sfp_object open failed")
+                return None
+
         else:
             offset = 0
             vendor_rev_width = XCVR_HW_REV_WIDTH_SFP
+            cable_length_width = XCVR_CABLE_LENGTH_WIDTH_SFP
+            interface_info_bulk_width = XCVR_INTFACE_BULK_WIDTH_SFP
+            sfp_type = 'SFP'
+
+            sfpi_obj = sff8472InterfaceId()
+            if sfpi_obj is None:
+                print("Error: sfp_object open failed")
+                return None
 
         file_path = self._get_port_eeprom_path(port_num, self.IDENTITY_EEPROM_ADDR)
         if not self._sfp_eeprom_present(file_path, 0):
@@ -651,14 +710,9 @@ class SfpUtilBase(object):
             print("Error: reading sysfs file %s" % file_path)
             return None
 
-        sfpi_obj = sff8436InterfaceId()
-        if sfpi_obj is None:
-            print("Error: sfp_object open failed")
-            return None
-
-        sfp_type_raw = self._read_eeprom_specific_bytes(sysfsfile_eeprom, (offset + XCVR_TYPE_OFFSET), XCVR_TYPE_WIDTH)
-        if sfp_type_raw is not None:
-            sfp_type_data = sfpi_obj.parse_sfp_type(sfp_type_raw, 0)
+        sfp_interface_bulk_raw = self._read_eeprom_specific_bytes(sysfsfile_eeprom, (offset + XCVR_INTFACE_BULK_OFFSET), interface_info_bulk_width)
+        if sfp_interface_bulk_raw is not None:
+            sfp_interface_bulk_data = sfpi_obj.parse_sfp_info_bulk(sfp_interface_bulk_raw, 0)
         else:
             return None
 
@@ -686,18 +740,61 @@ class SfpUtilBase(object):
         else:
             return None
 
+        sfp_vendor_oui_raw = self._read_eeprom_specific_bytes(sysfsfile_eeprom, (offset + XCVR_VENDOR_OUI_OFFSET), XCVR_VENDOR_OUI_WIDTH)
+        if sfp_vendor_oui_raw is not None:
+            sfp_vendor_oui_data = sfpi_obj.parse_vendor_oui(sfp_vendor_oui_raw, 0)
+        else:
+            return None
+
+        sfp_vendor_date_raw = self._read_eeprom_specific_bytes(sysfsfile_eeprom, (offset + XCVR_VENDOR_DATE_OFFSET), XCVR_VENDOR_DATE_WIDTH)
+        if sfp_vendor_date_raw is not None:
+            sfp_vendor_date_data = sfpi_obj.parse_vendor_date(sfp_vendor_date_raw, 0)
+        else:
+            return None
+
         try:
             sysfsfile_eeprom.close()
         except IOError:
             print("Error: closing sysfs file %s" % file_path)
             return None
 
-        transceiver_info_dict['type'] = sfp_type_data['data']['type']['value']
+        transceiver_info_dict['type'] = sfp_interface_bulk_data['data']['type']['value']
         transceiver_info_dict['manufacturename'] = sfp_vendor_name_data['data']['Vendor Name']['value']
         transceiver_info_dict['modelname'] = sfp_vendor_pn_data['data']['Vendor PN']['value']
         transceiver_info_dict['hardwarerev'] = sfp_vendor_rev_data['data']['Vendor Rev']['value']
         transceiver_info_dict['serialnum'] = sfp_vendor_sn_data['data']['Vendor SN']['value']
+        transceiver_info_dict['vendor_oui'] = sfp_vendor_oui_data['data']['Vendor OUI']['value']
+        transceiver_info_dict['vendor_date'] = sfp_vendor_date_data['data']['VendorDataCode(YYYY-MM-DD Lot)']['value']
+        transceiver_info_dict['Connector'] = sfp_interface_bulk_data['data']['Connector']['value']
+        transceiver_info_dict['encoding'] = sfp_interface_bulk_data['data']['EncodingCodes']['value']
+        transceiver_info_dict['ext_identifier'] = sfp_interface_bulk_data['data']['Extended Identifier']['value']
+        transceiver_info_dict['ext_rateselect_compliance'] = sfp_interface_bulk_data['data']['RateIdentifier']['value']
+        if sfp_type == 'QSFP':
+            for key in qsfp_cable_length_tup:
+                if key in sfp_interface_bulk_data['data']:
+                    transceiver_info_dict['cable_type'] = key
+                    transceiver_info_dict['cable_length'] = str(sfp_interface_bulk_data['data'][key]['value'])
 
+            for key in qsfp_compliance_code_tup:
+                if key in sfp_interface_bulk_data['data']['Specification compliance']['value']:
+                    compliance_code_dict[key] = sfp_interface_bulk_data['data']['Specification compliance']['value'][key]['value']
+            transceiver_info_dict['specification_compliance'] = str(compliance_code_dict)
+            
+            transceiver_info_dict['nominal_bit_rate'] = str(sfp_interface_bulk_data['data']['Nominal Bit Rate(100Mbs)']['value'])
+        else:
+            for key in sfp_cable_length_tup:
+                if key in sfp_interface_bulk_data['data']:
+                    transceiver_info_dict['cable_type'] = key
+                    transceiver_info_dict['cable_length'] = str(sfp_interface_bulk_data['data'][key]['value'])
+
+            for key in sfp_compliance_code_tup:
+                if key in sfp_interface_bulk_data['data']['Specification compliance']['value']:
+                    compliance_code_dict[key] = sfp_interface_bulk_data['data']['Specification compliance']['value'][key]['value']
+            transceiver_info_dict['specification_compliance'] = str(compliance_code_dict)
+
+            transceiver_info_dict['nominal_bit_rate'] = str(sfp_interface_bulk_data['data']['NominalSignallingRate(UnitsOf100Mbd)']['value'])
+    
+        #return sfp_interface_bulk_data
         return transceiver_info_dict
 
     def get_transceiver_dom_info_dict(self, port_num):


### PR DESCRIPTION
```
sonic_sfp: Extend sfputilbase to support xcvrd get more fields from SFP eeprom.

* Extends sff8446 and sff8472 with more fields parsing functions.
* Extend sfputilbase to return more fields to xcvrd.
* Add handling for OSFP. 
  
  Signed-off-by: Kebo Liu kebol@mellanox.com

```