### PR TITLE
changes needed for SNMP docker upgrade to stretch build

### DIFF
--- a/sonic_eeprom/eeprom_base.py
+++ b/sonic_eeprom/eeprom_base.py
@@ -13,6 +13,9 @@ from __future__ import print_function
 
 try:
     import exceptions
+except ImportError:
+    import builtins as exceptions
+try:
     import binascii
     import optparse
     import os

--- a/sonic_eeprom/eeprom_base.py
+++ b/sonic_eeprom/eeprom_base.py
@@ -12,9 +12,9 @@
 from __future__ import print_function
 
 try:
-    import exceptions
+    import exceptions			# Python 2
 except ImportError:
-    import builtins as exceptions
+    import builtins as exceptions	# Python 3
 try:
     import binascii
     import optparse

--- a/sonic_eeprom/eeprom_base.py
+++ b/sonic_eeprom/eeprom_base.py
@@ -12,9 +12,9 @@
 from __future__ import print_function
 
 try:
-    import exceptions			# Python 2
+    import exceptions              # Python 2
 except ImportError:
-    import builtins as exceptions	# Python 3
+    import builtins as exceptions  # Python 3
 try:
     import binascii
     import optparse

--- a/sonic_eeprom/eeprom_dts.py
+++ b/sonic_eeprom/eeprom_dts.py
@@ -2,9 +2,9 @@
 # Copyright 2012 Cumulus Networks LLC, all rights reserved
 
 try:
-    import exceptions
+    import exceptions			# Python 2
 except ImportError:
-    import builtins as exceptions
+    import builtins as exceptions	# Python 3
 try:
     import os
     import binascii

--- a/sonic_eeprom/eeprom_dts.py
+++ b/sonic_eeprom/eeprom_dts.py
@@ -2,9 +2,9 @@
 # Copyright 2012 Cumulus Networks LLC, all rights reserved
 
 try:
-    import exceptions			# Python 2
+    import exceptions              # Python 2
 except ImportError:
-    import builtins as exceptions	# Python 3
+    import builtins as exceptions  # Python 3
 try:
     import os
     import binascii

--- a/sonic_eeprom/eeprom_dts.py
+++ b/sonic_eeprom/eeprom_dts.py
@@ -2,8 +2,11 @@
 # Copyright 2012 Cumulus Networks LLC, all rights reserved
 
 try:
-    import os
     import exceptions
+except ImportError:
+    import builtins as exceptions
+try:
+    import os
     import binascii
     import subprocess
 except ImportError as e:

--- a/sonic_eeprom/eeprom_tlvinfo.py
+++ b/sonic_eeprom/eeprom_tlvinfo.py
@@ -12,15 +12,16 @@
 from __future__ import print_function
 
 try:
-    import exceptions 			# Python 2
+    import exceptions              # Python 2
 except ImportError:
-    import builtins as exceptions	# Python 3
+    import builtins as exceptions  # Python 3
 try:
     import binascii
     import optparse
     import os
     import sys
-    from . import eeprom_base		# Dot module supports both Python 2 and Python 3 using explicit relative import methods
+    from . import eeprom_base    # Dot module supports both Python 2 and Python 3 using explicit relative import methods
+    import redis
 except ImportError as e:
     raise ImportError (str(e) + "- required module not found")
 

--- a/sonic_eeprom/eeprom_tlvinfo.py
+++ b/sonic_eeprom/eeprom_tlvinfo.py
@@ -13,11 +13,14 @@ from __future__ import print_function
 
 try:
     import exceptions
+except ImportError:
+    import builtins as exceptions
+try:
     import binascii
     import optparse
     import os
     import sys
-    import eeprom_base
+    from . import eeprom_base
 except ImportError as e:
     raise ImportError (str(e) + "- required module not found")
 

--- a/sonic_eeprom/eeprom_tlvinfo.py
+++ b/sonic_eeprom/eeprom_tlvinfo.py
@@ -12,15 +12,15 @@
 from __future__ import print_function
 
 try:
-    import exceptions
+    import exceptions 			# Python 2
 except ImportError:
-    import builtins as exceptions
+    import builtins as exceptions	# Python 3
 try:
     import binascii
     import optparse
     import os
     import sys
-    from . import eeprom_base
+    from . import eeprom_base		# Dot module supports both Python 2 and Python 3 using explicit relative import methods
 except ImportError as e:
     raise ImportError (str(e) + "- required module not found")
 

--- a/sonic_sfp/sff8436.py
+++ b/sonic_sfp/sff8436.py
@@ -16,7 +16,7 @@ try:
     import types
     from math import log10
     from sff8024 import type_of_transceiver
-    from .sffbase import sffbase
+    from .sffbase import sffbase		# Dot module supports both Python 2 and Python 3 using explicit relative import methods
 except ImportError as e:
     raise ImportError (str(e) + "- required module not found")
 

--- a/sonic_sfp/sff8436.py
+++ b/sonic_sfp/sff8436.py
@@ -16,7 +16,7 @@ try:
     import types
     from math import log10
     from sff8024 import type_of_transceiver
-    from sffbase import sffbase
+    from .sffbase import sffbase
 except ImportError as e:
     raise ImportError (str(e) + "- required module not found")
 

--- a/sonic_sfp/sff8436.py
+++ b/sonic_sfp/sff8436.py
@@ -16,7 +16,7 @@ try:
     import types
     from math import log10
     from sff8024 import type_of_transceiver
-    from .sffbase import sffbase		# Dot module supports both Python 2 and Python 3 using explicit relative import methods
+    from .sffbase import sffbase    # Dot module supports both Python 2 and Python 3 using explicit relative import methods
 except ImportError as e:
     raise ImportError (str(e) + "- required module not found")
 

--- a/sonic_sfp/sff8472.py
+++ b/sonic_sfp/sff8472.py
@@ -18,7 +18,7 @@ try:
     import types
     from math import log10
     from sff8024 import type_of_transceiver
-    from .sffbase import sffbase
+    from .sffbase import sffbase		# Dot module supports both Python 2 and Python 3 using explicit relative import methods
 except ImportError as e:
     raise ImportError (str(e) + "- required module not found")
 

--- a/sonic_sfp/sff8472.py
+++ b/sonic_sfp/sff8472.py
@@ -18,7 +18,7 @@ try:
     import types
     from math import log10
     from sff8024 import type_of_transceiver
-    from .sffbase import sffbase		# Dot module supports both Python 2 and Python 3 using explicit relative import methods
+    from .sffbase import sffbase    # Dot module supports both Python 2 and Python 3 using explicit relative import methods
 except ImportError as e:
     raise ImportError (str(e) + "- required module not found")
 

--- a/sonic_sfp/sff8472.py
+++ b/sonic_sfp/sff8472.py
@@ -18,7 +18,7 @@ try:
     import types
     from math import log10
     from sff8024 import type_of_transceiver
-    from sffbase import sffbase
+    from .sffbase import sffbase
 except ImportError as e:
     raise ImportError (str(e) + "- required module not found")
 

--- a/sonic_sfp/sfputilbase.py
+++ b/sonic_sfp/sfputilbase.py
@@ -10,12 +10,12 @@ try:
     import binascii
     import os
     import re
-    from . import bcmshell			# Dot module supports both Python 2 and Python 3 using explicit relative import methods
+    from . import bcmshell       # Dot module supports both Python 2 and Python 3 using explicit relative import methods
     from sonic_eeprom import eeprom_dts
-    from .sff8472 import sff8472InterfaceId	# Dot module supports both Python 2 and Python 3 using explicit relative import methods
-    from .sff8472 import sff8472Dom		# Dot module supports both Python 2 and Python 3 using explicit relative import methods
-    from .sff8436 import sff8436InterfaceId	# Dot module supports both Python 2 and Python 3 using explicit relative import methods
-    from .sff8436 import sff8436Dom		# Dot module supports both Python 2 and Python 3 using explicit relative import methods
+    from .sff8472 import sff8472InterfaceId  # Dot module supports both Python 2 and Python 3 using explicit relative import methods
+    from .sff8472 import sff8472Dom    # Dot module supports both Python 2 and Python 3 using explicit relative import methods
+    from .sff8436 import sff8436InterfaceId  # Dot module supports both Python 2 and Python 3 using explicit relative import methods
+    from .sff8436 import sff8436Dom    # Dot module supports both Python 2 and Python 3 using explicit relative import methods
     from inf8628 import inf8628InterfaceId
 except ImportError as e:
     raise ImportError("%s - required module not found" % str(e))

--- a/sonic_sfp/sfputilbase.py
+++ b/sonic_sfp/sfputilbase.py
@@ -10,12 +10,12 @@ try:
     import binascii
     import os
     import re
-    import bcmshell
+    from . import bcmshell
     from sonic_eeprom import eeprom_dts
-    from sff8472 import sff8472InterfaceId
-    from sff8472 import sff8472Dom
-    from sff8436 import sff8436InterfaceId
-    from sff8436 import sff8436Dom
+    from .sff8472 import sff8472InterfaceId
+    from .sff8472 import sff8472Dom
+    from .sff8436 import sff8436InterfaceId
+    from .sff8436 import sff8436Dom
     from inf8628 import inf8628InterfaceId
 except ImportError as e:
     raise ImportError("%s - required module not found" % str(e))

--- a/sonic_sfp/sfputilbase.py
+++ b/sonic_sfp/sfputilbase.py
@@ -10,12 +10,12 @@ try:
     import binascii
     import os
     import re
-    from . import bcmshell
+    from . import bcmshell			# Dot module supports both Python 2 and Python 3 using explicit relative import methods
     from sonic_eeprom import eeprom_dts
-    from .sff8472 import sff8472InterfaceId
-    from .sff8472 import sff8472Dom
-    from .sff8436 import sff8436InterfaceId
-    from .sff8436 import sff8436Dom
+    from .sff8472 import sff8472InterfaceId	# Dot module supports both Python 2 and Python 3 using explicit relative import methods
+    from .sff8472 import sff8472Dom		# Dot module supports both Python 2 and Python 3 using explicit relative import methods
+    from .sff8436 import sff8436InterfaceId	# Dot module supports both Python 2 and Python 3 using explicit relative import methods
+    from .sff8436 import sff8436Dom		# Dot module supports both Python 2 and Python 3 using explicit relative import methods
     from inf8628 import inf8628InterfaceId
 except ImportError as e:
     raise ImportError("%s - required module not found" % str(e))


### PR DESCRIPTION
Signed-off-by: Sangita Maity [samaity@linkedin.com](mailto:samaity@linkedin.com)

**- What I did**

I was getting lots of import error during SNMP docker upgrade to stretch build. Made changes accordingly to fix those issues. May be python compatibility issue as by default it is using python3 and there's no exceptions module in python3

**- How I did it**
Made it compatible with python3 whenever required.

**- How to verify it**
Use this PR with snmp docker upgrade PR in sonic-buildimage.