### PR TITLE
[sonic_sfp] Remove problematic gang port handling code

### DIFF
--- a/sonic_sfp/sfputilbase.py
+++ b/sonic_sfp/sfputilbase.py
@@ -384,15 +384,6 @@ class SfpUtilBase(object):
                 physical_to_logical[fp_port_index].append(
                     portname)
 
-            if (fp_port_index - last_fp_port_index) > 1:
-                # last port was a gang port
-                for p in range(last_fp_port_index+1, fp_port_index):
-                    logical_to_physical[last_portname].append(p)
-                    if physical_to_logical.get(p) is None:
-                        physical_to_logical[p] = [last_portname]
-                    else:
-                        physical_to_logical[p].append(last_portname)
-
             last_fp_port_index = fp_port_index
             last_portname = portname
 


### PR DESCRIPTION
remove the problematic gang port handling code from the "port_config.ini" parsing function, it can generate a wrong port mapping table in some port break case.  