### PR TITLE
[sonic_platform_base] Fix typos in platform base class api

### DIFF
--- a/sonic_platform_base/chassis_base.py
+++ b/sonic_platform_base/chassis_base.py
@@ -220,4 +220,4 @@ class ChassisBase(device_base.DeviceBase):
             An object derived from WatchdogBase representing the hardware
             watchdog device
         """
-        return _watchdog
+        return self._watchdog

--- a/sonic_platform_base/psu_base.py
+++ b/sonic_platform_base/psu_base.py
@@ -29,7 +29,7 @@ class PsuBase(device_base.DeviceBase):
             An object dervied from FanBase representing the fan module
             contained in this PSU
         """
-        return _fan
+        return self._fan
 
     def set_status_led(self, color):
         """


### PR DESCRIPTION
sonic_platform_base: fix two typos in platform base class API.

```
     modified:   chassis_base.py
     modified:   psu_base.py

```
Signed-off-by: Liu Kebo kebol@mellanox.com