### PR TITLE
more changes needed for SNMP docker upgrade to stretch build

### DIFF
--- a/sonic_sfp/inf8628.py
+++ b/sonic_sfp/inf8628.py
@@ -6,8 +6,8 @@
 from __future__ import print_function
 
 try:
-    from sff8024 import type_of_transceiver
-    from sffbase import sffbase
+    from .sff8024 import type_of_transceiver    # Dot module supports both Python 2 and Python 3 using explicit relative import methods
+    from .sffbase import sffbase    # Dot module supports both Python 2 and Python 3 using explicit relative import methods
 except ImportError as e:
     raise ImportError ("%s - required module not found" % e)
 

--- a/sonic_sfp/sff8436.py
+++ b/sonic_sfp/sff8436.py
@@ -15,7 +15,7 @@ try:
     import getopt
     import types
     from math import log10
-    from sff8024 import type_of_transceiver
+    from .sff8024 import type_of_transceiver    # Dot module supports both Python 2 and Python 3 using explicit relative import methods
     from .sffbase import sffbase    # Dot module supports both Python 2 and Python 3 using explicit relative import methods
 except ImportError as e:
     raise ImportError (str(e) + "- required module not found")

--- a/sonic_sfp/sff8472.py
+++ b/sonic_sfp/sff8472.py
@@ -17,7 +17,7 @@ try:
     import getopt
     import types
     from math import log10
-    from sff8024 import type_of_transceiver
+    from .sff8024 import type_of_transceiver    # Dot module supports both Python 2 and Python 3 using explicit relative import methods
     from .sffbase import sffbase    # Dot module supports both Python 2 and Python 3 using explicit relative import methods
 except ImportError as e:
     raise ImportError (str(e) + "- required module not found")

--- a/sonic_sfp/sfputilbase.py
+++ b/sonic_sfp/sfputilbase.py
@@ -16,7 +16,7 @@ try:
     from .sff8472 import sff8472Dom    # Dot module supports both Python 2 and Python 3 using explicit relative import methods
     from .sff8436 import sff8436InterfaceId  # Dot module supports both Python 2 and Python 3 using explicit relative import methods
     from .sff8436 import sff8436Dom    # Dot module supports both Python 2 and Python 3 using explicit relative import methods
-    from inf8628 import inf8628InterfaceId
+    from .inf8628 import inf8628InterfaceId    # Dot module supports both Python 2 and Python 3 using explicit relative import methods
 except ImportError as e:
     raise ImportError("%s - required module not found" % str(e))
 


### PR DESCRIPTION
Signed-off-by: Sangita Maity samaity@linkedin.com

- **What I did**

I was getting lots of import error during SNMP docker upgrade to stretch build. Made changes accordingly to fix those issues. May be python compatibility issue as by default it is using python3 and there's no exceptions module in python3

- **How I did it**
Made it compatible with python3 whenever required.

- **How to verify it**
Use this PR with snmp docker upgrade PR in sonic-buildimage.