### PR TITLE
[sonic_platform_base/chassis_base]: Add firmware management interface

### DIFF
--- a/sonic_platform_base/chassis_base.py
+++ b/sonic_platform_base/chassis_base.py
@@ -95,13 +95,27 @@ class ChassisBase(device_base.DeviceBase):
         """
         raise NotImplementedError
 
-    def get_component_versions(self):
+    def get_firmware_version(self, component):
         """
         Retrieves platform-specific hardware/firmware versions for chassis
         componenets such as BIOS, CPLD, FPGA, etc.
+        Args:
+            component: A string, the component name.
 
         Returns:
             A string containing platform-specific component versions
+        """
+        raise NotImplementedError
+
+    def install_component_firmware(self, component, image_path):
+        """
+        Install firmware to module
+        Args:
+            component: A string, the component name.
+            image_path: A string, path to firmware image.
+
+        Returns:
+            A boolean, True if install successfully, False if not
         """
         raise NotImplementedError
 

--- a/sonic_platform_base/chassis_base.py
+++ b/sonic_platform_base/chassis_base.py
@@ -46,7 +46,7 @@ class ChassisBase(device_base.DeviceBase):
     # available on the chassis
     _sfp_list = []
 
-    # List of component names that available on the chassis
+    # List of component names that are available on the chassis
     _component_name_list = []
 
     # Object derived from WatchdogBase for interacting with hardware watchdog
@@ -100,10 +100,10 @@ class ChassisBase(device_base.DeviceBase):
 
     def get_component_name_list(self):
         """
-        Retrieves chassis components list such as BIOS, CPLD, FPGA, etc.
+        Retrieves a list of the names of components available on the chassis (e.g., BIOS, CPLD, FPGA, etc.)
 
         Returns:
-            A list containing component name.
+            A list containing the names of components available on the chassis
         """
         return self._component_name_list
 
@@ -112,7 +112,7 @@ class ChassisBase(device_base.DeviceBase):
         Retrieves platform-specific hardware/firmware versions for chassis
         componenets such as BIOS, CPLD, FPGA, etc.
         Args:
-            component: A string, the component name.
+            component_name: A string, the component name.
 
         Returns:
             A string containing platform-specific component versions
@@ -121,13 +121,13 @@ class ChassisBase(device_base.DeviceBase):
 
     def install_component_firmware(self, component_name, image_path):
         """
-        Install firmware to module
+        Install firmware to component
         Args:
-            component: A string, the component name.
+            component_name: A string, the component name.
             image_path: A string, path to firmware image.
 
         Returns:
-            A boolean, True if install successfully, False if not
+            A boolean, True if install was successful, False if not
         """
         raise NotImplementedError
 

--- a/sonic_platform_base/chassis_base.py
+++ b/sonic_platform_base/chassis_base.py
@@ -47,7 +47,7 @@ class ChassisBase(device_base.DeviceBase):
     _sfp_list = []
 
     # List of component names that available on the chassis
-    _component_list = []
+    _component_name_list = []
 
     # Object derived from WatchdogBase for interacting with hardware watchdog
     _watchdog = None
@@ -98,16 +98,16 @@ class ChassisBase(device_base.DeviceBase):
         """
         raise NotImplementedError
 
-    def get_component_list(self):
+    def get_component_name_list(self):
         """
         Retrieves chassis components list such as BIOS, CPLD, FPGA, etc.
 
         Returns:
             A list containing component name.
         """
-        return self._component_list
+        return self._component_name_list
 
-    def get_firmware_version(self, component):
+    def get_firmware_version(self, component_name):
         """
         Retrieves platform-specific hardware/firmware versions for chassis
         componenets such as BIOS, CPLD, FPGA, etc.
@@ -119,7 +119,7 @@ class ChassisBase(device_base.DeviceBase):
         """
         raise NotImplementedError
 
-    def install_component_firmware(self, component, image_path):
+    def install_component_firmware(self, component_name, image_path):
         """
         Install firmware to module
         Args:

--- a/sonic_platform_base/chassis_base.py
+++ b/sonic_platform_base/chassis_base.py
@@ -46,6 +46,9 @@ class ChassisBase(device_base.DeviceBase):
     # available on the chassis
     _sfp_list = []
 
+    # List of component names that available on the chassis
+    _component_list = []
+
     # Object derived from WatchdogBase for interacting with hardware watchdog
     _watchdog = None
 
@@ -94,6 +97,15 @@ class ChassisBase(device_base.DeviceBase):
             to pass a description of the reboot cause.
         """
         raise NotImplementedError
+
+    def get_component_list(self):
+        """
+        Retrieves chassis components list such as BIOS, CPLD, FPGA, etc.
+
+        Returns:
+            A list containing component name.
+        """
+        return self._component_list
 
     def get_firmware_version(self, component):
         """

--- a/sonic_platform_base/module_base.py
+++ b/sonic_platform_base/module_base.py
@@ -33,6 +33,9 @@ class ModuleBase(device_base.DeviceBase):
     # available on the module
     _sfp_list = []
 
+    # List of component names that available on the chassis
+    _component_list = []
+
     def get_base_mac(self):
         """
         Retrieves the base MAC address for the module
@@ -63,6 +66,39 @@ class ModuleBase(device_base.DeviceBase):
             Ex. { ‘0x21’:’AG9064’, ‘0x22’:’V1.0’, ‘0x23’:’AG9064-0109867821’,
                   ‘0x24’:’001c0f000fcd0a’, ‘0x25’:’02/03/2018 16:22:00’,
                   ‘0x26’:’01’, ‘0x27’:’REV01’, ‘0x28’:’AG9064-C2358-16G’}
+        """
+        raise NotImplementedError
+
+    def get_component_list(self):
+        """
+        Retrieves chassis components list such as BIOS, CPLD, FPGA, etc.
+
+        Returns:
+            A list containing component name.
+        """
+        return self._component_list
+
+    def get_firmware_version(self, component):
+        """
+        Retrieves platform-specific hardware/firmware versions for chassis
+        componenets such as BIOS, CPLD, FPGA, etc.
+        Args:
+            component: A string, the component name.
+
+        Returns:
+            A string containing platform-specific component versions
+        """
+        raise NotImplementedError
+
+    def install_component_firmware(self, component, image_path):
+        """
+        Install firmware to module
+        Args:
+            component: A string, the component name.
+            image_path: A string, path to firmware image.
+
+        Returns:
+            A boolean, True if install successfully, False if not
         """
         raise NotImplementedError
 

--- a/sonic_platform_base/module_base.py
+++ b/sonic_platform_base/module_base.py
@@ -34,7 +34,7 @@ class ModuleBase(device_base.DeviceBase):
     _sfp_list = []
 
     # List of component names that available on the chassis
-    _component_list = []
+    _component_name_list = []
 
     def get_base_mac(self):
         """
@@ -69,16 +69,16 @@ class ModuleBase(device_base.DeviceBase):
         """
         raise NotImplementedError
 
-    def get_component_list(self):
+    def get_component_name_list(self):
         """
         Retrieves chassis components list such as BIOS, CPLD, FPGA, etc.
 
         Returns:
             A list containing component name.
         """
-        return self._component_list
+        return self._component_name_list
 
-    def get_firmware_version(self, component):
+    def get_firmware_version(self, component_name):
         """
         Retrieves platform-specific hardware/firmware versions for chassis
         componenets such as BIOS, CPLD, FPGA, etc.
@@ -90,7 +90,7 @@ class ModuleBase(device_base.DeviceBase):
         """
         raise NotImplementedError
 
-    def install_component_firmware(self, component, image_path):
+    def install_component_firmware(self, component_name, image_path):
         """
         Install firmware to module
         Args:

--- a/sonic_platform_base/module_base.py
+++ b/sonic_platform_base/module_base.py
@@ -71,10 +71,10 @@ class ModuleBase(device_base.DeviceBase):
 
     def get_component_name_list(self):
         """
-        Retrieves chassis components list such as BIOS, CPLD, FPGA, etc.
+        Retrieves a list of the names of components available on the module (e.g., BIOS, CPLD, FPGA, etc.)
 
         Returns:
-            A list containing component name.
+            A list containing the names of components available on the module.
         """
         return self._component_name_list
 
@@ -83,7 +83,7 @@ class ModuleBase(device_base.DeviceBase):
         Retrieves platform-specific hardware/firmware versions for chassis
         componenets such as BIOS, CPLD, FPGA, etc.
         Args:
-            component: A string, the component name.
+            component_name: A string, the component name.
 
         Returns:
             A string containing platform-specific component versions
@@ -92,13 +92,13 @@ class ModuleBase(device_base.DeviceBase):
 
     def install_component_firmware(self, component_name, image_path):
         """
-        Install firmware to module
+        Install firmware to component
         Args:
-            component: A string, the component name.
+            component_name: A string, the component name.
             image_path: A string, path to firmware image.
 
         Returns:
-            A boolean, True if install successfully, False if not
+            A boolean, True if install was successful, False if not
         """
         raise NotImplementedError
 


### PR DESCRIPTION
Add base class for firmware management API
(https://github.com/Azure/sonic-buildimage/pull/3013)

Signed-off-by: Wirut Getbamrung wgetbumr@celestica.com