### PR TITLE
sonic_sfp: avoid possible key error in get_physical_to_logical()

### DIFF
--- a/sonic_sfp/sfputilbase.py
+++ b/sonic_sfp/sfputilbase.py
@@ -544,7 +544,7 @@ class SfpUtilBase(object):
     def get_physical_to_logical(self, port_num):
         """Returns list of logical ports for the given physical port"""
 
-        return self.physical_to_logical[port_num]
+        return self.physical_to_logical.get(port_num)
 
     def get_logical_to_physical(self, logical_port):
         """Returns list of physical ports for the given logical port"""


### PR DESCRIPTION
This is part of PR#31 of sonic-platform-daemons, there could be a key error
in get_physical_to_logical() in SFP monitor due to a timing issue, and
it will later be recovered automatically.

Signed-off-by: Dante (Kuo-Jung) Su <dante.su@broadcom.com>