### PR TITLE
readd type_abbrv_name in sonic_sfp/sff8436.py

### DIFF
--- a/sonic_sfp/sff8436.py
+++ b/sonic_sfp/sff8436.py
@@ -16,6 +16,7 @@ try:
     import types
     from math import log10
     from .sff8024 import type_of_transceiver    # Dot module supports both Python 2 and Python 3 using explicit relative import methods
+    from .sff8024 import type_abbrv_name    # Dot module supports both Python 2 and Python 3 using explicit relative import methods
     from .sffbase import sffbase    # Dot module supports both Python 2 and Python 3 using explicit relative import methods
 except ImportError as e:
     raise ImportError (str(e) + "- required module not found")
@@ -352,6 +353,11 @@ class sff8436InterfaceId(sffbase):
                  'size':1,
                  'type' : 'enum',
                  'decode' : type_of_transceiver},
+             'type_abbrv_name':
+                {'offset':0,
+                 'size':1,
+                 'type' : 'enum',
+                 'decode' : type_abbrv_name},
              'Extended Identifier':
                 {'offset':1,
                  'size':1,


### PR DESCRIPTION
1. add type_abbrv_name handling which was removed inadvertently in PR #38 from sonic_sfp/sff8436.py