### PR TITLE
[sonic_sfp] Interpret sff 'int' element =0 as valid value

### DIFF
--- a/sonic_platform_base/sonic_sfp/sffbase.py
+++ b/sonic_platform_base/sonic_sfp/sffbase.py
@@ -132,9 +132,7 @@ class sffbase(object):
                               offset + size)
 
         elif type == 'int':
-            data = int(eeprom_data[offset], 16)
-            if data != 0:
-                value = data
+            value = int(eeprom_data[offset], 16)
 
         elif type == 'date':
             value = self.convert_date_to_string(eeprom_data, offset,


### PR DESCRIPTION
In get_transceiver_info_dict() an exception is generated on access to sfp_interface_bulk_data element that was not added in case SFP EEPROM 'int' value was zero. Actually, zero should be valid value as well.

Signed-off-by: Andriy Kokhan <akokhan@barefootnetworks.com>