### PR TITLE
[xcvrd] Fix crashing due to missing fields of some module types

### DIFF
--- a/sonic_platform_base/sonic_sfp/sfputilbase.py
+++ b/sonic_platform_base/sonic_sfp/sfputilbase.py
@@ -876,6 +876,8 @@ class SfpUtilBase(object):
             transceiver_info_dict['encoding'] = sfp_interface_bulk_data['data']['EncodingCodes']['value']
             transceiver_info_dict['ext_identifier'] = sfp_interface_bulk_data['data']['Extended Identifier']['value']
             transceiver_info_dict['ext_rateselect_compliance'] = sfp_interface_bulk_data['data']['RateIdentifier']['value']
+            transceiver_info_dict['cable_type'] = "Unknown"
+            transceiver_info_dict['cable_length'] = "Unknown"
             if sfp_type == 'QSFP':
                 for key in qsfp_cable_length_tup:
                     if key in sfp_interface_bulk_data['data']:


### PR DESCRIPTION
- Added default cable_type and cable_length.

From SFF-8436 regarding cable length fields:
"A value of zero means that the Module does not support [this mode] or that the length information must be determined from the Module technology."

It is possible that all cable length fields in eeprom are 0, and this would lead to xcvrd crashing due to fetching of this data. Fallback is added in this case.