### PR TITLE
Added new API to interact with the platform components

### DIFF
--- a/sonic_platform_base/chassis_base.py
+++ b/sonic_platform_base/chassis_base.py
@@ -26,6 +26,10 @@ class ChassisBase(device_base.DeviceBase):
     REBOOT_CAUSE_HARDWARE_OTHER = "Hardware - Other"
     REBOOT_CAUSE_NON_HARDWARE = "Non-Hardware"
 
+    # List of ComponentBase-derived objects representing all components
+    # available on the chassis
+    _component_list = []
+
     # List of ModuleBase-derived objects representing all modules
     # available on the chassis (for use with modular chassis)
     _module_list = []
@@ -45,9 +49,6 @@ class ChassisBase(device_base.DeviceBase):
     # List of SfpBase-derived objects representing all sfps
     # available on the chassis
     _sfp_list = []
-
-    # List of component names that are available on the chassis
-    _component_name_list = []
 
     # Object derived from WatchdogBase for interacting with hardware watchdog
     _watchdog = None
@@ -101,38 +102,48 @@ class ChassisBase(device_base.DeviceBase):
         """
         raise NotImplementedError
 
-    def get_component_name_list(self):
+    ##############################################
+    # Component methods
+    ##############################################
+
+    def get_num_components(self):
         """
-        Retrieves a list of the names of components available on the chassis (e.g., BIOS, CPLD, FPGA, etc.)
+        Retrieves the number of components available on this chassis
 
         Returns:
-            A list containing the names of components available on the chassis
+            An integer, the number of components available on this chassis
         """
-        return self._component_name_list
+        return len(self._component_list)
 
-    def get_firmware_version(self, component_name):
+    def get_all_components(self):
         """
-        Retrieves platform-specific hardware/firmware versions for chassis
-        componenets such as BIOS, CPLD, FPGA, etc.
+        Retrieves all components available on this chassis
+
+        Returns:
+            A list of objects derived from ComponentBase representing all components
+            available on this chassis
+        """
+        return self._component_list
+
+    def get_component(self, index):
+        """
+        Retrieves component represented by (0-based) index <index>
+
         Args:
-            component_name: A string, the component name.
+            index: An integer, the index (0-based) of the component to retrieve
 
         Returns:
-            A string containing platform-specific component versions
+            An object dervied from ComponentBase representing the specified component
         """
-        raise NotImplementedError
+        component = None
 
-    def install_component_firmware(self, component_name, image_path):
-        """
-        Install firmware to component
-        Args:
-            component_name: A string, the component name.
-            image_path: A string, path to firmware image.
+        try:
+            component = self._component_list[index]
+        except IndexError:
+            sys.stderr.write("Component index {} out of range (0-{})\n".format(
+                             index, len(self._component_list)-1))
 
-        Returns:
-            A boolean, True if install was successful, False if not
-        """
-        raise NotImplementedError
+        return component
 
     ##############################################
     # Module methods

--- a/sonic_platform_base/component_base.py
+++ b/sonic_platform_base/component_base.py
@@ -1,0 +1,52 @@
+#
+# component_base.py
+#
+# Abstract base class for implementing a platform-specific class
+# to interact with a chassis/module component (e.g., BIOS, CPLD, FPGA, etc.) in SONiC
+#
+
+
+class ComponentBase(object):
+    """
+    Abstract base class for implementing a platform-specific class
+    to interact with a chassis/module component (e.g., BIOS, CPLD, FPGA, etc.)
+    """
+
+    def get_name(self):
+        """
+        Retrieves the name of the component
+
+        Returns:
+            A string containing the name of the component
+        """
+        raise NotImplementedError
+
+    def get_description(self):
+        """
+        Retrieves the description of the component
+
+        Returns:
+            A string containing the description of the component
+        """
+        raise NotImplementedError
+
+    def get_firmware_version(self):
+        """
+        Retrieves the firmware version of the component
+
+        Returns:
+            A string containing the firmware version of the component
+        """
+        raise NotImplementedError
+
+    def install_firmware(self, image_path):
+        """
+        Installs firmware to the component
+
+        Args:
+            image_path: A string, path to firmware image
+
+        Returns:
+            A boolean, True if install was successful, False if not
+        """
+        raise NotImplementedError

--- a/sonic_platform_base/module_base.py
+++ b/sonic_platform_base/module_base.py
@@ -17,6 +17,10 @@ class ModuleBase(device_base.DeviceBase):
     # Device type definition. Note, this is a constant.
     DEVICE_TYPE = "module"
 
+    # List of ComponentBase-derived objects representing all components
+    # available on the module
+    _component_list = []
+
     # List of FanBase-derived objects representing all fans
     # available on the module 
     _fan_list = []
@@ -32,9 +36,6 @@ class ModuleBase(device_base.DeviceBase):
     # List of SfpBase-derived objects representing all sfps
     # available on the module
     _sfp_list = []
-
-    # List of component names that available on the chassis
-    _component_name_list = []
 
     def get_base_mac(self):
         """
@@ -69,38 +70,48 @@ class ModuleBase(device_base.DeviceBase):
         """
         raise NotImplementedError
 
-    def get_component_name_list(self):
+    ##############################################
+    # Component methods
+    ##############################################
+
+    def get_num_components(self):
         """
-        Retrieves a list of the names of components available on the module (e.g., BIOS, CPLD, FPGA, etc.)
+        Retrieves the number of components available on this module
 
         Returns:
-            A list containing the names of components available on the module.
+            An integer, the number of components available on this module
         """
-        return self._component_name_list
+        return len(self._component_list)
 
-    def get_firmware_version(self, component_name):
+    def get_all_components(self):
         """
-        Retrieves platform-specific hardware/firmware versions for chassis
-        componenets such as BIOS, CPLD, FPGA, etc.
+        Retrieves all components available on this module
+
+        Returns:
+            A list of objects derived from ComponentBase representing all components
+            available on this module
+        """
+        return self._component_list
+
+    def get_component(self, index):
+        """
+        Retrieves component represented by (0-based) index <index>
+
         Args:
-            component_name: A string, the component name.
+            index: An integer, the index (0-based) of the component to retrieve
 
         Returns:
-            A string containing platform-specific component versions
+            An object dervied from ComponentBase representing the specified component
         """
-        raise NotImplementedError
+        component = None
 
-    def install_component_firmware(self, component_name, image_path):
-        """
-        Install firmware to component
-        Args:
-            component_name: A string, the component name.
-            image_path: A string, path to firmware image.
+        try:
+            component = self._component_list[index]
+        except IndexError:
+            sys.stderr.write("PSU index {} out of range (0-{})\n".format(
+                             index, len(self._component_list)-1))
 
-        Returns:
-            A boolean, True if install was successful, False if not
-        """
-        raise NotImplementedError
+        return component
 
     ##############################################
     # Fan module methods

--- a/sonic_platform_base/module_base.py
+++ b/sonic_platform_base/module_base.py
@@ -108,7 +108,7 @@ class ModuleBase(device_base.DeviceBase):
         try:
             component = self._component_list[index]
         except IndexError:
-            sys.stderr.write("PSU index {} out of range (0-{})\n".format(
+            sys.stderr.write("Component index {} out of range (0-{})\n".format(
                              index, len(self._component_list)-1))
 
         return component


### PR DESCRIPTION
Signed-off-by: Nazarii Hnydyn <nazariig@mellanox.com>

The purpose of these changes are:
* Improve component API scalability
* Avoid code duplication: both chassis_base.py and module_base.py share the same methods:  
_get_component_name_list(), get_firmware_version(), install_component_firmware()_
* Add new description field (later will be used by fwutil):  
_get_description()_