### PR TITLE
[sfp_base] Raise NotImplementedError exceptions instead of returning them

### DIFF
--- a/sonic_platform_base/sfp_base.py
+++ b/sonic_platform_base/sfp_base.py
@@ -41,7 +41,7 @@ class SfpBase(device_base.DeviceBase):
         vendor_oui                 |1*255VCHAR     |vendor OUI
         ========================================================================
         """
-        return NotImplementedError
+        raise NotImplementedError
 
     def get_transceiver_bulk_status(self):
         """
@@ -69,7 +69,7 @@ class SfpBase(device_base.DeviceBase):
                                    |               |for example, tx2power stands for tx power of channel 2.
         ========================================================================
         """
-        return NotImplementedError
+        raise NotImplementedError
 
     def get_transceiver_threshold_info(self):
         """
@@ -102,7 +102,7 @@ class SfpBase(device_base.DeviceBase):
         txbiaslowwarning           |FLOAT          |Low Warning Threshold value of tx Bias Current in mA.
         ========================================================================
         """
-        return NotImplementedError
+        raise NotImplementedError
 
     def get_reset_status(self):
         """
@@ -111,7 +111,7 @@ class SfpBase(device_base.DeviceBase):
         Returns:
             A Boolean, True if reset enabled, False if disabled
         """
-        return NotImplementedError
+        raise NotImplementedError
 
     def get_rx_los(self):
         """
@@ -121,7 +121,7 @@ class SfpBase(device_base.DeviceBase):
             A Boolean, True if SFP has RX LOS, False if not.
             Note : RX LOS status is latched until a call to get_rx_los or a reset.
         """
-        return NotImplementedError
+        raise NotImplementedError
 
     def get_tx_fault(self):
         """
@@ -131,7 +131,7 @@ class SfpBase(device_base.DeviceBase):
             A Boolean, True if SFP has TX fault, False if not
             Note : TX fault status is lached until a call to get_tx_fault or a reset.
         """
-        return NotImplementedError
+        raise NotImplementedError
 
     def get_tx_disable(self):
         """
@@ -140,7 +140,7 @@ class SfpBase(device_base.DeviceBase):
         Returns:
             A Boolean, True if tx_disable is enabled, False if disabled
         """
-        return NotImplementedError
+        raise NotImplementedError
 
     def get_tx_disable_channel(self):
         """
@@ -152,7 +152,7 @@ class SfpBase(device_base.DeviceBase):
             As an example, a returned value of 0x5 indicates that channel 0 
             and channel 2 have been disabled.
         """
-        return NotImplementedError
+        raise NotImplementedError
 
     def get_lpmode(self):
         """
@@ -161,7 +161,7 @@ class SfpBase(device_base.DeviceBase):
         Returns:
             A Boolean, True if lpmode is enabled, False if disabled
         """
-        return NotImplementedError
+        raise NotImplementedError
 
     def get_power_override(self):
         """
@@ -170,7 +170,7 @@ class SfpBase(device_base.DeviceBase):
         Returns:
             A Boolean, True if power-override is enabled, False if disabled
         """
-        return NotImplementedError
+        raise NotImplementedError
     
     def get_temperature(self):
         """
@@ -179,7 +179,7 @@ class SfpBase(device_base.DeviceBase):
         Returns:
             An integer number of current temperature in Celsius
         """
-        return NotImplementedError
+        raise NotImplementedError
 
 
     def get_voltage(self):
@@ -189,7 +189,7 @@ class SfpBase(device_base.DeviceBase):
         Returns:
             An integer number of supply voltage in mV
         """
-        return NotImplementedError
+        raise NotImplementedError
     
     def get_tx_bias(self):
         """
@@ -200,7 +200,7 @@ class SfpBase(device_base.DeviceBase):
             for channel 0 to channel 4.
             Ex. ['110.09', '111.12', '108.21', '112.09']
         """
-        return NotImplementedError
+        raise NotImplementedError
     
     def get_rx_power(self):
         """
@@ -211,7 +211,7 @@ class SfpBase(device_base.DeviceBase):
             power in mW for channel 0 to channel 4.
             Ex. ['1.77', '1.71', '1.68', '1.70']
         """
-        return NotImplementedError
+        raise NotImplementedError
     
     def get_tx_power(self):
         """
@@ -222,7 +222,7 @@ class SfpBase(device_base.DeviceBase):
             for channel 0 to channel 4.
             Ex. ['1.86', '1.86', '1.86', '1.86']
         """
-        return NotImplementedError
+        raise NotImplementedError
     
     def reset(self):
         """
@@ -231,7 +231,7 @@ class SfpBase(device_base.DeviceBase):
         Returns:
             A boolean, True if successful, False if not
         """
-        return NotImplementedError
+        raise NotImplementedError
     
     def tx_disable(self, tx_disable):
         """
@@ -244,7 +244,7 @@ class SfpBase(device_base.DeviceBase):
         Returns:
             A boolean, True if tx_disable is set successfully, False if not
         """
-        return NotImplementedError
+        raise NotImplementedError
     
     def tx_disable_channel(self, channel, disable):
         """
@@ -259,7 +259,7 @@ class SfpBase(device_base.DeviceBase):
         Returns:
             A boolean, True if successful, False if not
         """
-        return NotImplementedError
+        raise NotImplementedError
     
     def set_lpmode(self, lpmode):
         """
@@ -272,7 +272,7 @@ class SfpBase(device_base.DeviceBase):
         Returns:
             A boolean, True if lpmode is set successfully, False if not
         """
-        return NotImplementedError
+        raise NotImplementedError
     
     def set_power_override(self, power_override, power_set):
         """
@@ -293,4 +293,4 @@ class SfpBase(device_base.DeviceBase):
             A boolean, True if power-override and power_set are set successfully,
             False if not
         """
-        return NotImplementedError
+        raise NotImplementedError


### PR DESCRIPTION
Exceptions should be raised, not returned.