### PR TITLE
[sfputilbase] Fix xcvr and sfpshow crash with OSFP

### DIFF
--- a/sonic_platform_base/sonic_sfp/sfputilbase.py
+++ b/sonic_platform_base/sonic_sfp/sfputilbase.py
@@ -1103,7 +1103,11 @@ class SfpUtilBase(object):
                              ]
         transceiver_dom_threshold_info_dict = dict.fromkeys(dom_info_dict_keys, 'N/A')
 
-        if port_num in self.qsfp_ports:
+        if port_num in self.osfp_ports:
+            # Below part is added to avoid fail xcvrd, shall be implemented later
+            return transceiver_dom_threshold_info_dict
+
+        elif port_num in self.qsfp_ports:
             file_path = self._get_port_eeprom_path(port_num, self.IDENTITY_EEPROM_ADDR)
             if not self._sfp_eeprom_present(file_path, 0):
                 return None

--- a/sonic_platform_base/sonic_sfp/sfputilbase.py
+++ b/sonic_platform_base/sonic_sfp/sfputilbase.py
@@ -777,7 +777,7 @@ class SfpUtilBase(object):
             transceiver_info_dict['ext_rateselect_compliance'] = 'N/A'
             transceiver_info_dict['cable_type'] = 'N/A'
             transceiver_info_dict['cable_length'] = 'N/A'
-            transceiver_info_dict['specification_compliance'] = 'N/A'
+            transceiver_info_dict['specification_compliance'] = '{}'
             transceiver_info_dict['nominal_bit_rate'] = 'N/A'
 
         else:


### PR DESCRIPTION
In __get_transceiver_dom_threshold_info_dict()__ ad a case to handle osfp port type.
In get_transceiver_info_dict() update __specification_compliance__ from N/A to empty dictionary.
This prevents error in _sfpshow_ trying to prase data from STATE_DB with _eval_ function.