### PR TITLE
[sonic_platform_base] Reallocate empty lists in the constructor of the base class

### DIFF
--- a/sonic_platform_base/chassis_base.py
+++ b/sonic_platform_base/chassis_base.py
@@ -28,33 +28,41 @@ class ChassisBase(device_base.DeviceBase):
 
     # List of ComponentBase-derived objects representing all components
     # available on the chassis
-    _component_list = []
+    _component_list = None
 
     # List of ModuleBase-derived objects representing all modules
     # available on the chassis (for use with modular chassis)
-    _module_list = []
+    _module_list = None
 
     # List of FanBase-derived objects representing all fans
     # available on the chassis
-    _fan_list = []
+    _fan_list = None
 
     # List of PsuBase-derived objects representing all power supply units
     # available on the chassis
-    _psu_list = []
+    _psu_list = None
 
     # List of ThermalBase-derived objects representing all thermals
     # available on the chassis
-    _thermal_list = []
+    _thermal_list = None
 
     # List of SfpBase-derived objects representing all sfps
     # available on the chassis
-    _sfp_list = []
+    _sfp_list = None
 
     # Object derived from WatchdogBase for interacting with hardware watchdog
     _watchdog = None
 
     # Object derived from eeprom_tlvinfo.TlvInfoDecoder indicating the eeprom on the chassis
     _eeprom = None
+
+    def __init__(self):
+        self._component_list = []
+        self._module_list = []
+        self._fan_list = []
+        self._psu_list = []
+        self._thermal_list = []
+        self._sfp_list = []
 
     def get_base_mac(self):
         """

--- a/sonic_platform_base/module_base.py
+++ b/sonic_platform_base/module_base.py
@@ -19,23 +19,30 @@ class ModuleBase(device_base.DeviceBase):
 
     # List of ComponentBase-derived objects representing all components
     # available on the module
-    _component_list = []
+    _component_list = None
 
     # List of FanBase-derived objects representing all fans
     # available on the module 
-    _fan_list = []
+    _fan_list = None
 
     # List of PsuBase-derived objects representing all power supply units
     # available on the module
-    _psu_list = []
+    _psu_list = None
 
     # List of ThermalBase-derived objects representing all thermals
     # available on the module
-    _thermal_list = []
+    _thermal_list = None
 
     # List of SfpBase-derived objects representing all sfps
     # available on the module
-    _sfp_list = []
+    _sfp_list = None
+
+    def __init__(self):
+        self._component_list = []
+        self._fan_list = []
+        self._psu_list = []
+        self._thermal_list = []
+        self._sfp_list = []
 
     def get_base_mac(self):
         """

--- a/sonic_platform_base/psu_base.py
+++ b/sonic_platform_base/psu_base.py
@@ -23,7 +23,10 @@ class PsuBase(device_base.DeviceBase):
 
     # List of FanBase-derived objects representing all fans
     # available on the PSU
-    _fan_list = []
+    _fan_list = None
+
+    def __init__(self):
+        self._fan_list = []
 
     def get_num_fans(self):
         """


### PR DESCRIPTION
… the base class

When we use a mutable object as a default value in the base class, a value that can be modified in place in the subclasses, such as the empty lists of
the chassis base class, and it is most likely unwanted.

And hence, this commit will try to address this issue by allocating new empty
list objects at the constructor of the base class, and the subclass should
rely on the constructor of superclass for this.

As a result, it simplifies the source code, and reduce the maintenance efforts

Signed-off-by: Dante (Kuo-Jung) Su <dante.su@broadcom.com>