### PR TITLE
[sonic_platform_common/fan]add fan direction "not applicable"

### DIFF
--- a/sonic_platform_base/fan_base.py
+++ b/sonic_platform_base/fan_base.py
@@ -18,6 +18,7 @@ class FanBase(device_base.DeviceBase):
     # Possible fan directions (relative to port-side of device)
     FAN_DIRECTION_INTAKE = "intake"
     FAN_DIRECTION_EXHAUST = "exhaust"
+    FAN_DIRECTION_NOT_APPLICABLE = "not applicable"
 
     # Possible fan status LED colors
     STATUS_LED_COLOR_GREEN = "green"

--- a/sonic_platform_base/fan_base.py
+++ b/sonic_platform_base/fan_base.py
@@ -18,7 +18,7 @@ class FanBase(device_base.DeviceBase):
     # Possible fan directions (relative to port-side of device)
     FAN_DIRECTION_INTAKE = "intake"
     FAN_DIRECTION_EXHAUST = "exhaust"
-    FAN_DIRECTION_NOT_APPLICABLE = "not applicable"
+    FAN_DIRECTION_NOT_APPLICABLE = "N/A"
 
     # Possible fan status LED colors
     STATUS_LED_COLOR_GREEN = "green"


### PR DESCRIPTION
[sonic_platform_common/fan]add fan direction "not applicable"
it is for the devices that don't support fetching fan's direction for now