### PR TITLE
DeviceBase.get_name should raise NotImplementedError like other membe…

### DIFF
--- a/sonic_platform_base/device_base.py
+++ b/sonic_platform_base/device_base.py
@@ -18,6 +18,8 @@ class DeviceBase(object):
         Returns:
             string: The name of the device
         """
+        raise NotImplementedError
+
 
     def get_presence(self):
         """


### PR DESCRIPTION
Fix issue: DeviceBase.get_name does not raise NotImplementedError like other members.

