### PR TITLE
[eeprom]: Add DB checksum field

### DIFF
--- a/sonic_platform_base/sonic_eeprom/eeprom_tlvinfo.py
+++ b/sonic_platform_base/sonic_eeprom/eeprom_tlvinfo.py
@@ -329,6 +329,15 @@ class TlvInfoDecoder(eeprom_base.EepromDecoder):
             self.__print_db(client, self._TLV_CODE_VENDOR_EXT, num_vendor_ext)
 
         self.__print_db(client, self._TLV_CODE_CRC_32)
+
+        print("")
+
+        is_valid = client.hget('EEPROM_INFO|Checksum', 'Valid')
+        if is_valid != '1':
+            print("(*** checksum invalid)")
+        else:
+            print("(checksum valid)")
+
         return 0
 
     def update_eeprom_db(self, e):
@@ -378,6 +387,15 @@ class TlvInfoDecoder(eeprom_base.EepromDecoder):
             fvs['Num_vendor_ext'] = self._TLV_NUM_VENDOR_EXT
             client.hmset('EEPROM_INFO|{}'.format(hex(self._TLV_CODE_VENDOR_EXT)), fvs)
             fvs.clear()
+
+        (is_valid, valid_crc) = self.is_checksum_valid(e)
+        if is_valid:
+            fvs['Valid'] = '1'
+        else:
+            fvs['Valid'] = '0'
+
+        client.hmset('EEPROM_INFO|Checksum', fvs)
+        fvs.clear()
 
         fvs['Initialized'] = '1'
         client.hmset('EEPROM_INFO|State', fvs)


### PR DESCRIPTION
Signed-off-by: Nazarii Hnydyn <nazariig@mellanox.com>

Summary:
Add EEPROM DB Checksum field:
```bash
root@sonic:/etc/sonic# redis-cli -n 6 KEYS '*' | grep EEPROM
EEPROM_INFO|0x25
EEPROM_INFO|0x28
EEPROM_INFO|0x22
EEPROM_INFO|0x2b
EEPROM_INFO|0x2a
EEPROM_INFO|State
EEPROM_INFO|0x24
EEPROM_INFO|0x29
EEPROM_INFO|TlvHeader
EEPROM_INFO|0xfd
EEPROM_INFO|0x21
EEPROM_INFO|0x23
EEPROM_INFO|0x26
EEPROM_INFO|Checksum

root@sonic:/etc/sonic# redis-cli -n 6 HGETALL 'EEPROM_INFO|Checksum'
1) "Valid"
2) "1"
```

Old version:
```bash
root@sonic:/etc/sonic# decode-syseeprom -d
TlvInfo Header:
   Id String:    TlvInfo
   Version:      1
   Total Length: 595
TLV Name             Code Len Value
-------------------- ---- --- -----
...
CRC-32               0xFE   4 0x9A9E52B0
```

New version:
```bash
root@sonic:/etc/sonic# decode-syseeprom -d
TlvInfo Header:
   Id String:    TlvInfo
   Version:      1
   Total Length: 595
TLV Name             Code Len Value
-------------------- ---- --- -----
...
CRC-32               0xFE   4 0x9A9E52B0

(checksum valid)
```