### PR TITLE
[sfputilbase | sfputilhelper] Add support of platform.json

### DIFF
--- a/sonic_platform_base/sonic_sfp/sfputilbase.py
+++ b/sonic_platform_base/sonic_sfp/sfputilbase.py
@@ -17,8 +17,17 @@ try:
     from .sff8436 import sff8436InterfaceId  # Dot module supports both Python 2 and Python 3 using explicit relative import methods
     from .sff8436 import sff8436Dom    # Dot module supports both Python 2 and Python 3 using explicit relative import methods
     from .inf8628 import inf8628InterfaceId    # Dot module supports both Python 2 and Python 3 using explicit relative import methods
+    from portconfig import get_port_config
+    from collections import OrderedDict
+    from natsort import natsorted
+    from sonic_daemon_base.daemon_base import DaemonBase
+
 except ImportError as e:
     raise ImportError("%s - required module not found" % str(e))
+
+# Global Variable
+PLATFORM_JSON = 'platform.json'
+PORT_CONFIG_INI = 'portconfig.ini'
 
 # definitions of the offset and width for values in XCVR info eeprom
 XCVR_INTFACE_BULK_OFFSET = 0
@@ -369,13 +378,58 @@ class SfpUtilBase(object):
         first = 1
         port_pos_in_file = 0
         parse_fmt_port_config_ini = False
+        parse_fmt_platform_json = False
+
+        parse_fmt_port_config_ini = (os.path.basename(porttabfile) == PORT_CONFIG_INI)
+        parse_fmt_platform_json = (os.path.basename(porttabfile) == PLATFORM_JSON)
+
+        (platform, hwsku) =  DaemonBase.get_platform_and_hwsku()
+        if(parse_fmt_platform_json):
+            ports, _ = get_port_config(hwsku, platform)
+            if not ports:
+                print('Failed to get port config', file=sys.stderr)
+                sys.exit(1)
+            else:
+                logical_list = []
+                for intf in ports.keys():
+                    logical_list.append(intf)
+
+                logical = natsorted(logical_list, key=lambda y: y.lower())
+                logical_to_bcm, logical_to_physical, physical_to_logical = OrderedDict(),  OrderedDict(),  OrderedDict()
+
+                for intf_name in logical:
+                    bcm_port = str(port_pos_in_file)
+                    logical_to_bcm[intf_name] = "xe"+ bcm_port
+
+                    if 'index' in ports[intf_name].keys():
+                        fp_port_index = ports[intf_name]['index']
+                        logical_to_physical[intf_name] = [fp_port_index]
+
+                    if physical_to_logical.get(fp_port_index) is None:
+                        physical_to_logical[fp_port_index] = [intf_name]
+                    else:
+                        physical_to_logical[fp_port_index].append(intf_name)
+
+                    port_pos_in_file +=1
+
+                self.logical = logical
+                self.logical_to_bcm = logical_to_bcm
+                self.logical_to_physical = logical_to_physical
+                self.physical_to_logical = physical_to_logical
+
+                """
+                print("logical: {}".format(self.logical))
+                print("logical to bcm: {}".format(self.logical_to_bcm))
+                print("logical to physical: {}".format(self.logical_to_physical))
+                print("physical to logical: {}".format( self.physical_to_logical))
+                """
+                sys.exit(0)
+
 
         try:
             f = open(porttabfile)
         except:
             raise
-
-        parse_fmt_port_config_ini = (os.path.basename(porttabfile) == "port_config.ini")
 
         # Read the porttab file and generate dicts
         # with mapping for future reference.
@@ -431,8 +485,7 @@ class SfpUtilBase(object):
             if physical_to_logical.get(fp_port_index) is None:
                 physical_to_logical[fp_port_index] = [portname]
             else:
-                physical_to_logical[fp_port_index].append(
-                    portname)
+                physical_to_logical[fp_port_index].append(portname)
 
             last_fp_port_index = fp_port_index
             last_portname = portname

--- a/sonic_platform_base/sonic_sfp/sfputilbase.py
+++ b/sonic_platform_base/sonic_sfp/sfputilbase.py
@@ -21,7 +21,7 @@ try:
     from collections import OrderedDict
     from natsort import natsorted
     from sonic_daemon_base.daemon_base import DaemonBase
-
+    import sys
 except ImportError as e:
     raise ImportError("%s - required module not found" % str(e))
 
@@ -383,7 +383,7 @@ class SfpUtilBase(object):
         parse_fmt_port_config_ini = (os.path.basename(porttabfile) == PORT_CONFIG_INI)
         parse_fmt_platform_json = (os.path.basename(porttabfile) == PLATFORM_JSON)
 
-        (platform, hwsku) =  DaemonBase.get_platform_and_hwsku()
+        (platform, hwsku) =  DaemonBase().get_platform_and_hwsku()
         if(parse_fmt_platform_json):
             ports, _ = get_port_config(hwsku, platform)
             if not ports:
@@ -423,7 +423,7 @@ class SfpUtilBase(object):
                 print("logical to physical: {}".format(self.logical_to_physical))
                 print("physical to logical: {}".format( self.physical_to_logical))
                 """
-                sys.exit(0)
+                return None
 
 
         try:

--- a/sonic_platform_base/sonic_sfp/sfputilhelper.py
+++ b/sonic_platform_base/sonic_sfp/sfputilhelper.py
@@ -14,7 +14,7 @@ try:
     from collections import OrderedDict
     from natsort import natsorted
     from sonic_daemon_base.daemon_base import DaemonBase
-
+    import sys
 except ImportError as e:
     raise ImportError("%s - required module not found" % str(e))
 
@@ -55,7 +55,7 @@ class SfpUtilHelper(object):
         parse_fmt_port_config_ini = (os.path.basename(porttabfile) == PORT_CONFIG_INI)
         parse_fmt_platform_json = (os.path.basename(porttabfile) == PLATFORM_JSON)
 
-        (platform, hwsku) =  DaemonBase.get_platform_and_hwsku()
+        (platform, hwsku) =  DaemonBase().get_platform_and_hwsku()
         if(parse_fmt_platform_json):
             ports, _ = get_port_config(hwsku, platform)
             if not ports:
@@ -92,7 +92,7 @@ class SfpUtilHelper(object):
                 print("logical to physical: {}".format(self.logical_to_physical))
                 print("physical to logical: {}".format( self.physical_to_logical))
                 """
-                sys.exit(0)
+                return None
 
 
         try:


### PR DESCRIPTION
Signed-off-by: Sangita Maity <sangitamaity0211@gmail.com>


> [Azure/sonic-utilities/pull/767](https://github.com/Azure/sonic-utilities/pull/767) PR in **_sonic_utilities_** submodule(filename: [sfputil/main.py](https://github.com/Azure/sonic-utilities/pull/767/files) depends on this PR.

All three PRs are necessary to run `show interfaces transceiver` command.

1. [Azure/sonic-buildimage#3912](https://github.com/Azure/sonic-buildimage/pull/3912)
2. [Azure/sonic-platform-common#72](https://github.com/Azure/sonic-platform-common/pull/72)
3. https://github.com/Azure/sonic-utilities/pull/767



### - What I did

Add support of platform.json in **_sfputilbase_** and **_sfputilhelper_** file. Code is duplicated in **_sfputilhelper_** file as sfputilbase is an abstract base class. So, it cant be instantiated.
```
admin@lnos-x1-a-fab01:~$ sudo sfputil show
/usr/share/sonic/device/x86_64-cel_seastone-r0/Seastone-DX010-10-50/platform.json
logical: ['Ethernet0', 'Ethernet4', 'Ethernet5', 'Ethernet6', 'Ethernet7', 'Ethernet8', 'Ethernet9', 'Ethernet10', 'Ethernet11', 'Ethernet12', 'Ethernet13', 'Ethernet14', 'Ethernet16', 'Ethernet18', 'Ethernet19', 'Ethernet20', 'Ethernet21', 'Ethernet22', 'Ethernet23', 'Ethernet24', 'Ethernet25', 'Ethernet26', 'Ethernet27', 'Ethernet28', 'Ethernet29', 'Ethernet30', 'Ethernet31', 'Ethernet32', 'Ethernet33', 'Ethernet34', 'Ethernet35', 'Ethernet36', 'Ethernet37', 'Ethernet38', 'Ethernet39', 'Ethernet40', 'Ethernet41', 'Ethernet42', 'Ethernet43', 'Ethernet44', 'Ethernet45', 'Ethernet46', 'Ethernet47', 'Ethernet48', 'Ethernet49', 'Ethernet50', 'Ethernet51', 'Ethernet52', 'Ethernet53', 'Ethernet54', 'Ethernet55', 'Ethernet56', 'Ethernet57', 'Ethernet58', 'Ethernet59', 'Ethernet60', 'Ethernet61', 'Ethernet62', 'Ethernet63', 'Ethernet64', 'Ethernet65', 'Ethernet66', 'Ethernet67', 'Ethernet68', 'Ethernet69', 'Ethernet70', 'Ethernet71', 'Ethernet72', 'Ethernet73', 'Ethernet74', 'Ethernet75', 'Ethernet76', 'Ethernet77', 'Ethernet78', 'Ethernet79', 'Ethernet80', 'Ethernet81', 'Ethernet82', 'Ethernet83', 'Ethernet84', 'Ethernet85', 'Ethernet86', 'Ethernet87', 'Ethernet88', 'Ethernet89', 'Ethernet90', 'Ethernet91', 'Ethernet92', 'Ethernet93', 'Ethernet94', 'Ethernet95', 'Ethernet96', 'Ethernet98', 'Ethernet100', 'Ethernet102', 'Ethernet104', 'Ethernet106', 'Ethernet108', 'Ethernet110', 'Ethernet112', 'Ethernet114', 'Ethernet116', 'Ethernet118', 'Ethernet120', 'Ethernet122', 'Ethernet124', 'Ethernet126']

logical to bcm: OrderedDict([('Ethernet0', 'xe0'), ('Ethernet4', 'xe1'), ('Ethernet5', 'xe2'), ('Ethernet6', 'xe3'), ('Ethernet7', 'xe4'), ('Ethernet8', 'xe5'), ('Ethernet9', 'xe6'), ('Ethernet10', 'xe7'), ('Ethernet11', 'xe8'), ('Ethernet12', 'xe9'), ('Ethernet13', 'xe10'), ('Ethernet14', 'xe11'), ('Ethernet16', 'xe12'), ('Ethernet18', 'xe13'), ('Ethernet19', 'xe14'), ('Ethernet20', 'xe15'), ('Ethernet21', 'xe16'), ('Ethernet22', 'xe17'), ('Ethernet23', 'xe18'), ('Ethernet24', 'xe19'), ('Ethernet25', 'xe20'), ('Ethernet26', 'xe21'), ('Ethernet27', 'xe22'), ('Ethernet28', 'xe23'), ('Ethernet29', 'xe24'), ('Ethernet30', 'xe25'), ('Ethernet31', 'xe26'), ('Ethernet32', 'xe27'), ('Ethernet33', 'xe28'), ('Ethernet34', 'xe29'), ('Ethernet35', 'xe30'), ('Ethernet36', 'xe31'), ('Ethernet37', 'xe32'), ('Ethernet38', 'xe33'), ('Ethernet39', 'xe34'), ('Ethernet40', 'xe35'), ('Ethernet41', 'xe36'), ('Ethernet42', 'xe37'), ('Ethernet43', 'xe38'), ('Ethernet44', 'xe39'), ('Ethernet45', 'xe40'), ('Ethernet46', 'xe41'), ('Ethernet47', 'xe42'), ('Ethernet48', 'xe43'), ('Ethernet49', 'xe44'), ('Ethernet50', 'xe45'), ('Ethernet51', 'xe46'), ('Ethernet52', 'xe47'), ('Ethernet53', 'xe48'), ('Ethernet54', 'xe49'), ('Ethernet55', 'xe50'), ('Ethernet56', 'xe51'), ('Ethernet57', 'xe52'), ('Ethernet58', 'xe53'), ('Ethernet59', 'xe54'), ('Ethernet60', 'xe55'), ('Ethernet61', 'xe56'), ('Ethernet62', 'xe57'), ('Ethernet63', 'xe58'), ('Ethernet64', 'xe59'), ('Ethernet65', 'xe60'), ('Ethernet66', 'xe61'), ('Ethernet67', 'xe62'), ('Ethernet68', 'xe63'), ('Ethernet69', 'xe64'), ('Ethernet70', 'xe65'), ('Ethernet71', 'xe66'), ('Ethernet72', 'xe67'), ('Ethernet73', 'xe68'), ('Ethernet74', 'xe69'), ('Ethernet75', 'xe70'), ('Ethernet76', 'xe71'), ('Ethernet77', 'xe72'), ('Ethernet78', 'xe73'), ('Ethernet79', 'xe74'), ('Ethernet80', 'xe75'), ('Ethernet81', 'xe76'), ('Ethernet82', 'xe77'), ('Ethernet83', 'xe78'), ('Ethernet84', 'xe79'), ('Ethernet85', 'xe80'), ('Ethernet86', 'xe81'), ('Ethernet87', 'xe82'), ('Ethernet88', 'xe83'), ('Ethernet89', 'xe84'), ('Ethernet90', 'xe85'), ('Ethernet91', 'xe86'), ('Ethernet92', 'xe87'), ('Ethernet93', 'xe88'), ('Ethernet94', 'xe89'), ('Ethernet95', 'xe90'), ('Ethernet96', 'xe91'), ('Ethernet98', 'xe92'), ('Ethernet100', 'xe93'), ('Ethernet102', 'xe94'), ('Ethernet104', 'xe95'), ('Ethernet106', 'xe96'), ('Ethernet108', 'xe97'), ('Ethernet110', 'xe98'), ('Ethernet112', 'xe99'), ('Ethernet114', 'xe100'), ('Ethernet116', 'xe101'), ('Ethernet118', 'xe102'), ('Ethernet120', 'xe103'), ('Ethernet122', 'xe104'), ('Ethernet124', 'xe105'), ('Ethernet126', 'xe106')])

logical to physical: OrderedDict([('Ethernet0', ['1']), ('Ethernet4', ['2']), ('Ethernet5', ['2']), ('Ethernet6', ['2']), ('Ethernet7', ['2']), ('Ethernet8', ['3']), ('Ethernet9', ['3']), ('Ethernet10', ['3']), ('Ethernet11', ['3']), ('Ethernet12', ['4']), ('Ethernet13', ['4']), ('Ethernet14', ['4']), ('Ethernet16', ['5']), ('Ethernet18', ['5']), ('Ethernet19', ['5']), ('Ethernet20', ['5']), ('Ethernet21', ['5']), ('Ethernet22', ['5']), ('Ethernet23', ['5']), ('Ethernet24', ['6']), ('Ethernet25', ['6']), ('Ethernet26', ['6']), ('Ethernet27', ['6']), ('Ethernet28', ['7']), ('Ethernet29', ['7']), ('Ethernet30', ['7']), ('Ethernet31', ['7']), ('Ethernet32', ['8']), ('Ethernet33', ['8']), ('Ethernet34', ['8']), ('Ethernet35', ['8']), ('Ethernet36', ['9']), ('Ethernet37', ['9']), ('Ethernet38', ['9']), ('Ethernet39', ['9']), ('Ethernet40', ['10']), ('Ethernet41', ['10']), ('Ethernet42', ['10']), ('Ethernet43', ['10']), ('Ethernet44', ['11']), ('Ethernet45', ['11']), ('Ethernet46', ['11']), ('Ethernet47', ['11']), ('Ethernet48', ['12']), ('Ethernet49', ['12']), ('Ethernet50', ['12']), ('Ethernet51', ['12']), ('Ethernet52', ['13']), ('Ethernet53', ['13']), ('Ethernet54', ['13']), ('Ethernet55', ['13']), ('Ethernet56', ['14']), ('Ethernet57', ['14']), ('Ethernet58', ['14']), ('Ethernet59', ['14']), ('Ethernet60', ['15']), ('Ethernet61', ['15']), ('Ethernet62', ['15']), ('Ethernet63', ['15']), ('Ethernet64', ['16']), ('Ethernet65', ['16']), ('Ethernet66', ['16']), ('Ethernet67', ['16']), ('Ethernet68', ['17']), ('Ethernet69', ['17']), ('Ethernet70', ['17']), ('Ethernet71', ['17']), ('Ethernet72', ['18']), ('Ethernet73', ['18']), ('Ethernet74', ['18']), ('Ethernet75', ['18']), ('Ethernet76', ['19']), ('Ethernet77', ['19']), ('Ethernet78', ['19']), ('Ethernet79', ['19']), ('Ethernet80', ['20']), ('Ethernet81', ['20']), ('Ethernet82', ['20']), ('Ethernet83', ['20']), ('Ethernet84', ['21']), ('Ethernet85', ['21']), ('Ethernet86', ['21']), ('Ethernet87', ['21']), ('Ethernet88', ['22']), ('Ethernet89', ['22']), ('Ethernet90', ['22']), ('Ethernet91', ['22']), ('Ethernet92', ['23']), ('Ethernet93', ['23']), ('Ethernet94', ['23']), ('Ethernet95', ['23']), ('Ethernet96', ['24']), ('Ethernet98', ['24']), ('Ethernet100', ['25']), ('Ethernet102', ['25']), ('Ethernet104', ['26']), ('Ethernet106', ['26']), ('Ethernet108', ['27']), ('Ethernet110', ['27']), ('Ethernet112', ['28']), ('Ethernet114', ['28']), ('Ethernet116', ['29']), ('Ethernet118', ['29']), ('Ethernet120', ['30']), ('Ethernet122', ['30']), ('Ethernet124', ['31']), ('Ethernet126', ['31'])])

physical to logical: OrderedDict([('1', ['Ethernet0']), ('2', ['Ethernet4', 'Ethernet5', 'Ethernet6', 'Ethernet7']), ('3', ['Ethernet8', 'Ethernet9', 'Ethernet10', 'Ethernet11']), ('4', ['Ethernet12', 'Ethernet13', 'Ethernet14']), ('5', ['Ethernet16', 'Ethernet18', 'Ethernet19', 'Ethernet20', 'Ethernet21', 'Ethernet22', 'Ethernet23']), ('6', ['Ethernet24', 'Ethernet25', 'Ethernet26', 'Ethernet27']), ('7', ['Ethernet28', 'Ethernet29', 'Ethernet30', 'Ethernet31']), ('8', ['Ethernet32', 'Ethernet33', 'Ethernet34', 'Ethernet35']), ('9', ['Ethernet36', 'Ethernet37', 'Ethernet38', 'Ethernet39']), ('10', ['Ethernet40', 'Ethernet41', 'Ethernet42', 'Ethernet43']), ('11', ['Ethernet44', 'Ethernet45', 'Ethernet46', 'Ethernet47']), ('12', ['Ethernet48', 'Ethernet49', 'Ethernet50', 'Ethernet51']), ('13', ['Ethernet52', 'Ethernet53', 'Ethernet54', 'Ethernet55']), ('14', ['Ethernet56', 'Ethernet57', 'Ethernet58', 'Ethernet59']), ('15', ['Ethernet60', 'Ethernet61', 'Ethernet62', 'Ethernet63']), ('16', ['Ethernet64', 'Ethernet65', 'Ethernet66', 'Ethernet67']), ('17', ['Ethernet68', 'Ethernet69', 'Ethernet70', 'Ethernet71']), ('18', ['Ethernet72', 'Ethernet73', 'Ethernet74', 'Ethernet75']), ('19', ['Ethernet76', 'Ethernet77', 'Ethernet78', 'Ethernet79']), ('20', ['Ethernet80', 'Ethernet81', 'Ethernet82', 'Ethernet83']), ('21', ['Ethernet84', 'Ethernet85', 'Ethernet86', 'Ethernet87']), ('22', ['Ethernet88', 'Ethernet89', 'Ethernet90', 'Ethernet91']), ('23', ['Ethernet92', 'Ethernet93', 'Ethernet94', 'Ethernet95']), ('24', ['Ethernet96', 'Ethernet98']), ('25', ['Ethernet100', 'Ethernet102']), ('26', ['Ethernet104', 'Ethernet106']), ('27', ['Ethernet108', 'Ethernet110']), ('28', ['Ethernet112', 'Ethernet114']), ('29', ['Ethernet116', 'Ethernet118']), ('30', ['Ethernet120', 'Ethernet122']), ('31', ['Ethernet124', 'Ethernet126'])])
```


### - How I did it

### - How to verify it

Check whether all the below-mentioned CLI's are working correctly.

```admin@lnos-x1-a-fab01:~$ show interfaces transceiver --help
Usage: show interfaces transceiver [OPTIONS] COMMAND [ARGS]...

  Show SFP Transceiver information

Options:
  -?, -h, --help  Show this message and exit.

Commands:
  eeprom    Show interface transceiver EEPROM information
  lpmode    Show interface transceiver low-power mode status
  presence  Show interface transceiver presence
```
