### PR TITLE
SFP(sff8472 attributes) transciever eeprom attribute support.

### DIFF
--- a/sonic_platform_base/sonic_sfp/sff8472.py
+++ b/sonic_platform_base/sonic_sfp/sff8472.py
@@ -513,7 +513,7 @@ class sff8472InterfaceId(sffbase):
              'size':3,
              'type' : 'hex'}
         }
-    
+
     vendor_date = {
         'VendorDataCode(YYYY-MM-DD Lot)':
             {'offset':0,
@@ -569,7 +569,7 @@ class sff8472InterfaceId(sffbase):
 
     def parse_vendor_oui(self, sn_raw_data, start_pos):
         return sffbase.parse(self, self.vendor_oui, sn_raw_data, start_pos)
-    
+
     def dump_pretty(self):
         if self.interface_data == None:
             print('Object not initialized, nothing to print')
@@ -1175,6 +1175,90 @@ class sff8472Dom(sffbase):
              'type': 'func',
              'decode': {'func': calc_rx_power}}
         }
+    dom_module_monitor = {
+        'TempHighAlarm':
+            {'offset':0,
+            'bit':7,
+            'type': 'bitvalue'},
+        'TempLowAlarm':
+             {'offset':0,
+             'bit':6,
+             'type': 'bitvalue'},
+        'TempHighWarning':
+             {'offset': 4,
+             'bit': 7,
+             'type': 'bitvalue'},
+        'TempLowWarning':
+             {'offset': 4,
+             'bit': 6,
+             'type': 'bitvalue'},
+        'VccHighAlarm':
+             {'offset': 0,
+             'bit': 5,
+             'type': 'bitvalue'},
+        'VccLowAlarm':
+              {'offset': 0,
+              'bit': 4,
+              'type': 'bitvalue'},
+        'VccHighWarning':
+             {'offset': 4,
+             'bit': 5,
+             'type': 'bitvalue'},
+        'VccLowWarning':
+             {'offset': 4,
+             'bit': 4,
+             'type': 'bitvalue'}}
+
+    dom_channel_thresh_monitor_params = {
+          'BiasHighAlarm':
+              {'offset':0,
+              'bit':3,
+              'type': 'bitvalue'},
+          'BiasLowAlarm':
+              {'offset':0,
+              'bit':2,
+              'type': 'bitvalue'},
+          'BiasHighWarning':
+               {'offset':4,
+               'bit':3,
+               'type': 'bitvalue'},
+          'BiasLowWarning':
+                {'offset':4,
+                'bit':2,
+                'type': 'bitvalue'},
+          'TxPowerHighAlarm':
+                 {'offset':0,
+                 'bit':1,
+                 'type': 'bitvalue'},
+          'TxPowerLowAlarm':
+                 {'offset':0,
+                 'bit':0,
+                 'type': 'bitvalue'},
+          'TxPowerHighWarning':
+                  {'offset':4,
+                  'bit':1,
+                  'type': 'bitvalue'},
+          'TxPowerLowWarning':
+                  {'offset':4,
+                  'bit':0,
+                  'type': 'bitvalue'},
+          'RxPowerHighAlarm':
+                  {'offset':1,
+                  'bit':7,
+                  'type': 'bitvalue'},
+          'RxPowerLowAlarm':
+                  {'offset':1,
+                  'bit':6,
+                  'type': 'bitvalue'},
+          'RxPowerHighWarning':
+                 {'offset':5,
+                 'bit':7,
+                 'type': 'bitvalue'},
+          'RxPowerLowWarning':
+                 {'offset':5,
+                 'bit':6,
+                  'type': 'bitvalue'}
+    }
 
     def __init__(self, eeprom_raw_data=None, calibration_type=0):
         self._calibration_type = calibration_type
@@ -1200,6 +1284,14 @@ class sff8472Dom(sffbase):
         return sffbase.parse(self, self.dom_channel_monitor_params, eeprom_raw_data,
                     start_pos)
 
+    def parse_module_monitor_params(self, eeprom_raw_data, start_pos):
+        return sffbase.parse(self, self.dom_module_monitor, eeprom_raw_data,
+                    start_pos)
+
+    def parse_channel_thresh_monitor_params(self, eeprom_raw_data, start_pos):
+         return sffbase.parse(self, self.dom_channel_thresh_monitor_params, eeprom_raw_data,
+                     start_pos)
+
     def parse_alarm_warning_threshold(self, eeprom_raw_data, start_pos):
         return sffbase.parse(self, self.dom_aw_thresholds, eeprom_raw_data,
                     start_pos)
@@ -1217,3 +1309,4 @@ class sff8472Dom(sffbase):
 
     def get_data_pretty(self):
         return sffbase.get_data_pretty(self, self.dom_data)
+

--- a/sonic_platform_base/sonic_sfp/sfputilbase.py
+++ b/sonic_platform_base/sonic_sfp/sfputilbase.py
@@ -88,9 +88,10 @@ SFP_VOLT_OFFSET = 98
 SFP_VOLT_WIDTH = 2
 SFP_CHANNL_MON_OFFSET = 100
 SFP_CHANNL_MON_WIDTH = 6
-SFP_MODULE_THRESHOLD_OFFSET = 0
-SFP_MODULE_THRESHOLD_WIDTH = 56
-
+SFP_MODULE_THRESHOLD_OFFSET = 112
+SFP_MODULE_THRESHOLD_WIDTH = 5
+SFP_CHANNL_THRESHOLD_OFFSET = 112
+SFP_CHANNL_THRESHOLD_WIDTH = 6
 
 qsfp_cable_length_tup = ('Length(km)', 'Length OM3(2m)',
                          'Length OM2(m)', 'Length OM1(m)',
@@ -450,7 +451,6 @@ class SfpUtilBase(object):
         print("logical to physical: " + self.logical_to_physical)
         print("physical to logical: " + self.physical_to_logical)
         """
-
     def read_phytab_mappings(self, phytabfile):
         logical = []
         phytab_mappings = {}
@@ -1045,7 +1045,6 @@ class SfpUtilBase(object):
             sfpd_obj = sff8472Dom()
             if sfpd_obj is None:
                 return None
-
             dom_temperature_raw = self._read_eeprom_specific_bytes(sysfsfile_eeprom, (offset + SFP_TEMPE_OFFSET), SFP_TEMPE_WIDTH)
             if dom_temperature_raw is not None:
                 dom_temperature_data = sfpd_obj.parse_temperature(dom_temperature_raw, 0)
@@ -1086,7 +1085,6 @@ class SfpUtilBase(object):
             transceiver_dom_info_dict['tx4power'] = 'N/A'
 
         return transceiver_dom_info_dict
-
     def get_transceiver_dom_threshold_info_dict(self, port_num):
         transceiver_dom_threshold_info_dict = {}
 
@@ -1195,7 +1193,7 @@ class SfpUtilBase(object):
                                          (offset + SFP_CHANNL_THRESHOLD_OFFSET),
                                          SFP_CHANNL_THRESHOLD_WIDTH)
             if dom_channel_threshold_raw is not None:
-                dom_channel_threshold_data = sfpd_obj.parse_channel_monitor_params(dom_channel_threshold_raw, 0)
+                dom_channel_threshold_data = sfpd_obj.parse_channel_thresh_monitor_params(dom_channel_threshold_raw, 0)
             else:
                 return None
 
@@ -1279,3 +1277,4 @@ class SfpUtilBase(object):
          like {'-1':'system_not_ready'}.
         """
         return
+


### PR DESCRIPTION
 SFP(sff8472 attributes) transciever eeprom attribute support.
```
Traceback (most recent call last):
Nov  5 14:32:52.721493 sonic INFO pmon#supervisord: xcvrd   File "/usr/bin/xcvrd", line 1077, in <module>
Nov  5 14:32:52.723223 sonic INFO pmon#supervisord: xcvrd     main()
Nov  5 14:32:52.723775 sonic INFO pmon#supervisord: xcvrd   File "/usr/bin/xcvrd", line 1074, in main
Nov  5 14:32:52.724157 sonic INFO pmon#supervisord: xcvrd     xcvrd.run()
Nov  5 14:32:52.724486 sonic INFO pmon#supervisord: xcvrd   File "/usr/bin/xcvrd", line 1038, in run
Nov  5 14:32:52.724836 sonic INFO pmon#supervisord: xcvrd     self.init()
Nov  5 14:32:52.725176 sonic INFO pmon#supervisord: xcvrd   File "/usr/bin/xcvrd", line 1022, in init
Nov  5 14:32:52.725539 sonic INFO pmon#supervisord: xcvrd     post_port_sfp_dom_info_to_db(is_warm_start, self.stop_event)
Nov  5 14:32:52.725916 sonic INFO pmon#supervisord: xcvrd   File "/usr/bin/xcvrd", line 387, in post_port_sfp_dom_info_to_db
Nov  5 14:32:52.726245 sonic INFO pmon#supervisord: xcvrd     post_port_dom_threshold_info_to_db(logical_port_name, dom_tbl, stop_event)
Nov  5 14:32:52.726596 sonic INFO pmon#supervisord: xcvrd   File "/usr/bin/xcvrd", line 281, in post_port_dom_threshold_info_to_db
Nov  5 14:32:52.726903 sonic INFO pmon#supervisord: xcvrd     dom_info_dict = _wrapper_get_transceiver_dom_threshold_info(physical_port)
Nov  5 14:32:52.727353 sonic INFO pmon#supervisord: xcvrd   File "/usr/bin/xcvrd", line 148, in _wrapper_get_transceiver_dom_threshold_info
Nov  5 14:32:52.727798 sonic INFO pmon#supervisord: xcvrd     return platform_sfputil.get_transceiver_dom_threshold_info_dict(physical_port)
Nov  5 14:32:52.728183 sonic INFO pmon#supervisord: xcvrd   File "/usr/local/lib/python2.7/dist-packages/sonic_sfp/sfputilbase.py", line 1190, in get_transceiver_dom_threshold_info_dict
```