### PR TITLE
[sfputilbase.py] Don't try to print EEPROM sysfs file name if we failed to read from it

### DIFF
--- a/sonic_platform_base/sonic_sfp/sfputilbase.py
+++ b/sonic_platform_base/sonic_sfp/sfputilbase.py
@@ -321,7 +321,7 @@ class SfpUtilBase(object):
             sysfsfile_eeprom.seek(offset)
             raw = sysfsfile_eeprom.read(num_bytes)
         except IOError:
-            print("Error: reading sysfs file")
+            print("Error: reading EEPROM sysfs file")
             return None
 
         try:

--- a/sonic_platform_base/sonic_sfp/sfputilbase.py
+++ b/sonic_platform_base/sonic_sfp/sfputilbase.py
@@ -321,7 +321,7 @@ class SfpUtilBase(object):
             sysfsfile_eeprom.seek(offset)
             raw = sysfsfile_eeprom.read(num_bytes)
         except IOError:
-            print("Error: reading sysfs file %s")
+            print("Error: reading sysfs file")
             return None
 
         try:

--- a/sonic_platform_base/sonic_sfp/sfputilbase.py
+++ b/sonic_platform_base/sonic_sfp/sfputilbase.py
@@ -321,7 +321,7 @@ class SfpUtilBase(object):
             sysfsfile_eeprom.seek(offset)
             raw = sysfsfile_eeprom.read(num_bytes)
         except IOError:
-            print("Error: reading sysfs file %s" % sysfs_sfp_i2c_client_eeprom_path)
+            print("Error: reading sysfs file %s")
             return None
 
         try:


### PR DESCRIPTION
What I did:
    Remove undefined variable 'sysfs_sfp_i2c_client_eeprom_path'

Signed-off-by: chiourung_huang <chiourung_huang@edge-core.com>