### PR TITLE
[Mellanox] add abstract FanDrawerBase class to support fan drawer in platform API

### DIFF
--- a/sonic_platform_base/chassis_base.py
+++ b/sonic_platform_base/chassis_base.py
@@ -38,6 +38,10 @@ class ChassisBase(device_base.DeviceBase):
     # available on the chassis
     _fan_list = None
 
+    # List of FanDrawerBase-derived objects representing all fan drawers
+    # available on the chassis
+    _fan_drawer_list = None
+
     # List of PsuBase-derived objects representing all power supply units
     # available on the chassis
     _psu_list = None
@@ -63,6 +67,7 @@ class ChassisBase(device_base.DeviceBase):
         self._psu_list = []
         self._thermal_list = []
         self._sfp_list = []
+        self._fan_drawer_list = []
 
     def get_base_mac(self):
         """
@@ -242,6 +247,47 @@ class ChassisBase(device_base.DeviceBase):
                              index, len(self._fan_list)-1))
 
         return fan
+
+    def get_num_fan_drawers(self):
+        """
+        Retrieves the number of fan drawers available on this chassis
+
+        Returns:
+            An integer, the number of fan drawers available on this chassis
+        """
+        return len(self._fan_drawer_list)
+
+    def get_all_fan_drawers(self):
+        """
+        Retrieves all fan drawers available on this chassis
+
+        Returns:
+            A list of objects derived from FanDrawerBase representing all fan
+            drawers available on this chassis
+        """
+        return self._fan_drawer_list
+
+    def get_fan_drawer(self, index):
+        """
+        Retrieves fan drawers represented by (0-based) index <index>
+
+        Args:
+            index: An integer, the index (0-based) of the fan drawer to
+            retrieve
+
+        Returns:
+            An object dervied from FanDrawerBase representing the specified fan
+            drawer
+        """
+        fan_drawer = None
+
+        try:
+            fan_drawer = self._fan_drawer_list[index]
+        except IndexError:
+            sys.stderr.write("Fan drawer index {} out of range (0-{})\n".format(
+                             index, len(self._fan_drawer_list)-1))
+
+        return fan_drawer
 
     ##############################################
     # PSU methods

--- a/sonic_platform_base/fan_drawer_base.py
+++ b/sonic_platform_base/fan_drawer_base.py
@@ -1,0 +1,60 @@
+#
+# fan_drawer_base.py
+#
+# Abstract base class for implementing a platform-specific class with which
+# to interact with a fan drawer module in SONiC
+#
+
+from . import device_base
+
+
+class FanDrawerBase(device_base.DeviceBase):
+    """
+    Abstract base class for interfacing with a fan drawer
+    """
+    # Device type definition. Note, this is a constant.
+    DEVICE_TYPE = "fan_drawer"
+
+    def __init__(self):
+        self._fan_list = []
+
+    def get_num_fans(self):
+        """
+        Retrieves the number of fans available on this fan drawer
+
+        Returns:
+            An integer, the number of fan modules available on this fan drawer
+        """
+        return len(self._fan_list)
+
+    def get_all_fans(self):
+        """
+        Retrieves all fan modules available on this fan drawer
+
+        Returns:
+            A list of objects derived from FanBase representing all fan
+            modules available on this fan drawer
+        """
+        return self._fan_list
+
+    def set_status_led(self, color):
+        """
+        Sets the state of the fan drawer status LED
+
+        Args:
+            color: A string representing the color with which to set the
+                   fan drawer status LED
+
+        Returns:
+            bool: True if status LED state is set successfully, False if not
+        """
+        raise NotImplementedError
+
+    def get_status_led(self, color):
+        """
+        Gets the state of the fan drawer LED
+
+        Returns:
+            A string, one of the predefined STATUS_LED_COLOR_* strings above
+        """
+        raise NotImplementedError


### PR DESCRIPTION
What I did:

1. Add an abstract class FanDrawerBase
2. Modify existing ChassisBase class to hold a list of FanDrawerBase objects