### PR TITLE
[201911][component]: Introduce new firmware management API

### DIFF
--- a/sonic_platform_base/component_base.py
+++ b/sonic_platform_base/component_base.py
@@ -34,19 +34,72 @@ class ComponentBase(object):
         """
         Retrieves the firmware version of the component
 
+        Note: the firmware version will be read from HW
+
         Returns:
             A string containing the firmware version of the component
         """
         raise NotImplementedError
 
+    def get_available_firmware_version(self, image_path):
+        """
+        Retrieves the available firmware version of the component
+
+        Note: the firmware version will be read from image
+
+        Args:
+            image_path: A string, path to firmware image
+
+        Returns:
+            A string containing the available firmware version of the component
+        """
+        raise NotImplementedError
+
+    def get_firmware_update_notification(self, image_path):
+        """
+        Retrieves a notification on what should be done in order to complete
+        the component firmware update
+
+        Args:
+            image_path: A string, path to firmware image
+
+        Returns:
+            A string containing the component firmware update notification if required.
+            By default 'None' value will be used, which indicates that no actions are required
+        """
+        return None
+
     def install_firmware(self, image_path):
         """
         Installs firmware to the component
+
+        This API performs firmware installation only: this may/may not be the same as firmware update.
+        In case platform component requires some extra steps (apart from calling Low Level Utility)
+        to load the installed firmware (e.g, reboot, power cycle, etc.) - this must be done manually by user
+
+        Note: in case immediate actions are required to complete the component firmware update
+        (e.g., reboot, power cycle, etc.) - will be done automatically by API and no return value provided
 
         Args:
             image_path: A string, path to firmware image
 
         Returns:
             A boolean, True if install was successful, False if not
+        """
+        raise NotImplementedError
+
+    def update_firmware(self, image_path):
+        """
+        Updates firmware of the component
+
+        This API performs firmware update: it assumes firmware installation and loading in a single call.
+        In case platform component requires some extra steps (apart from calling Low Level Utility)
+        to load the installed firmware (e.g, reboot, power cycle, etc.) - this will be done automatically by API
+
+        Args:
+            image_path: A string, path to firmware image
+
+        Raises:
+            RuntimeError: update failed
         """
         raise NotImplementedError


### PR DESCRIPTION
Signed-off-by: Nazarii Hnydyn <nazariig@mellanox.com>

**Summary:**
The purpose of this PR is to propagate some new component firmware management APIs which are intended to make the process more versatile. These new API's will be used mostly to extend fwutil functionality in order to support new platform components (e.g, SSD).

**Motivation:**
1. Inform user in advance about required component firmware update actions when operating in manual mode
2. Allow fwutil to read component firmware version directly from image instead of configuration file if not provided