### PR TITLE
[chassis_base] Add platform API support for system LED

### DIFF
--- a/sonic_platform_base/chassis_base.py
+++ b/sonic_platform_base/chassis_base.py
@@ -387,6 +387,26 @@ class ChassisBase(device_base.DeviceBase):
         """
         raise NotImplementedError
 
+    def get_asic_temperature(self):
+        """
+        Retrieves current temperature reading from ASIC sensor
+
+        Returns:
+            A float number of current temperature in Celsius up to nearest thousandth
+            of one degree Celsius, e.g. 30.125 
+        """
+        raise NotImplementedError
+
+    def get_asic_temperature_threshold(self):
+        """
+        Retrieves the high threshold temperature of ASIC
+
+        Returns:
+            A float number, the high threshold temperature of ASIC in Celsius
+            up to nearest thousandth of one degree Celsius, e.g. 30.125
+        """
+        raise NotImplementedError
+
     ##############################################
     # SFP methods
     ##############################################
@@ -432,6 +452,33 @@ class ChassisBase(device_base.DeviceBase):
                              index, len(self._sfp_list)-1))
 
         return sfp
+
+    ##############################################
+    # System LED methods
+    ##############################################
+
+    def set_status_led(self, color):
+        """
+        Sets the state of the system LED
+
+        Args:
+            color: A string representing the color with which to set the
+                   system LED
+
+        Returns:
+            bool: True if system LED state is set successfully, False if not
+        """
+        raise NotImplementedError
+
+    def get_status_led(self):
+        """
+        Gets the state of the system LED
+
+        Returns:
+            A string, one of the valid LED color strings which could be vendor
+            specified.
+        """
+        raise NotImplementedError
 
     ##############################################
     # Other methods

--- a/sonic_platform_base/chassis_base.py
+++ b/sonic_platform_base/chassis_base.py
@@ -61,7 +61,7 @@ class ChassisBase(device_base.DeviceBase):
     _eeprom = None
 
     # System status LED
-    _led = None
+    _status_led = None
 
     def __init__(self):
         self._component_list = []

--- a/sonic_platform_base/chassis_base.py
+++ b/sonic_platform_base/chassis_base.py
@@ -60,6 +60,9 @@ class ChassisBase(device_base.DeviceBase):
     # Object derived from eeprom_tlvinfo.TlvInfoDecoder indicating the eeprom on the chassis
     _eeprom = None
 
+    # System status LED
+    _led = None
+
     def __init__(self):
         self._component_list = []
         self._module_list = []
@@ -384,26 +387,6 @@ class ChassisBase(device_base.DeviceBase):
         Retrieves thermal manager class on this chassis
         :return: A class derived from ThermalManagerBase representing the
         specified thermal manager. ThermalManagerBase is returned as default
-        """
-        raise NotImplementedError
-
-    def get_asic_temperature(self):
-        """
-        Retrieves current temperature reading from ASIC sensor
-
-        Returns:
-            A float number of current temperature in Celsius up to nearest thousandth
-            of one degree Celsius, e.g. 30.125 
-        """
-        raise NotImplementedError
-
-    def get_asic_temperature_threshold(self):
-        """
-        Retrieves the high threshold temperature of ASIC
-
-        Returns:
-            A float number, the high threshold temperature of ASIC in Celsius
-            up to nearest thousandth of one degree Celsius, e.g. 30.125
         """
         raise NotImplementedError
 


### PR DESCRIPTION
Why I did this?

To support system health feature, we need get/set system LED status.

How I did this?

Add 2 new platform API to chassis_base.py for vendor to implement:
- set_status_led
- get_status_led