### PR TITLE
Changes in fan and psu base classes (1.0 platform API) related to pddf_2.0

### DIFF
--- a/sonic_fan/fan_base.py
+++ b/sonic_fan/fan_base.py
@@ -61,7 +61,7 @@ class FanBase(object):
     
     def get_speed(self, index):
         """
-        Retrieves the speed of a Front FAN in the tray in revolutions per minute defined
+        Retrieves the speed of a FAN in the tray in revolutions per minute defined
                 by 1-based index <index>
 
         :param index: An integer, 1-based index of the FAN of which to query speed
@@ -69,16 +69,6 @@ class FanBase(object):
         """
         return 0
 
-    def get_speed_rear(self, index):
-        """
-        Retrieves the speed of a rear FAN in the tray (applicable only for 2-fan tray) 
-                in revolutions per minute defined by 1-based index <index>
-
-        :param index: An integer, 1-based index of the FAN of which to query speed
-        :return: integer, denoting rear FAN speed
-        """
-        return 0
-    
     def set_speed(self, val):
         """
         Sets the speed of all the FANs to a value denoted by the duty-cycle percentage val

--- a/sonic_psu/psu_base.py
+++ b/sonic_psu/psu_base.py
@@ -88,29 +88,29 @@ class PsuBase(object):
         Retrieves the ouput volatage in milli volts of a power supply unit (PSU) defined
                 by 1-based index <idx>
         :param idx: An integer, 1-based index of the PSU of which to query o/p volatge
-        :return: An integer, value of o/p voltage in mV if PSU is good, else zero
+        :return: A float, value of o/p voltage in Volts if PSU is good, else zero
         """
-        return 0
+        return 0.0
 
     def get_output_current(self, idx):
         """
         Retrieves the output current in milli amperes of a power supply unit (PSU) defined
                 by 1-based index <idx>
         :param idx: An integer, 1-based index of the PSU of which to query o/p current
-        :return: An integer, value of o/p current in mA if PSU is good, else zero
+        :return: A float, value of o/p current in Amps if PSU is good, else zero
         """
-        return 0
+        return 0.0
 
     def get_output_power(self, idx):
         """
         Retrieves the output power in micro watts of a power supply unit (PSU) defined
                 by 1-based index <idx>
         :param idx: An integer, 1-based index of the PSU of which to query o/p power
-        :return: An integer, value of o/p power in micro Watts if PSU is good, else zero
+        :return: A float, value of o/p power in Watts if PSU is good, else zero
         """
-        return 0
+        return 0.0
 
-    def get_fan_speed(self, idx, fan_idx):
+    def get_fan_rpm(self, idx, fan_idx):
         """
         Retrieves the speed of fan, in rpm, denoted by 1-based <fan_idx> of a power 
                 supply unit (PSU) defined by 1-based index <idx>


### PR DESCRIPTION
Small changes in 1.0 platform plugins psu_base.py and fan_base.py. Changes are related to PDDF 2.0 changes. 
psu_base.py:
 - psu_fan speed API name change 
 - Changing the voltage, current and power units to 
fan_base.py:
 - Individual fans are counted instead of fantrays units
 - get_speed_rear() is not required

Depends on:
https://github.com/Azure/SONiC/pull/536