### PR TITLE
[sfputil] fix typo:  portconfig.ini to port_config.ini

### DIFF
--- a/sonic_platform_base/sonic_sfp/sfputilbase.py
+++ b/sonic_platform_base/sonic_sfp/sfputilbase.py
@@ -27,7 +27,7 @@ except ImportError as e:
 
 # Global Variable
 PLATFORM_JSON = 'platform.json'
-PORT_CONFIG_INI = 'portconfig.ini'
+PORT_CONFIG_INI = 'port_config.ini'
 
 # definitions of the offset and width for values in XCVR info eeprom
 XCVR_INTFACE_BULK_OFFSET = 0

--- a/sonic_platform_base/sonic_sfp/sfputilhelper.py
+++ b/sonic_platform_base/sonic_sfp/sfputilhelper.py
@@ -20,7 +20,7 @@ except ImportError as e:
 
 # Global Variable
 PLATFORM_JSON = 'platform.json'
-PORT_CONFIG_INI = 'portconfig.ini'
+PORT_CONFIG_INI = 'port_config.ini'
 
 class SfpUtilHelper(object):
     # List to specify filter for sfp_ports


### PR DESCRIPTION
Fix typo:  portconfig.ini to port_config.ini

The typo is introduced by https://github.com/Azure/sonic-platform-common/commit/4040326948d334b774daf4b6495f096e251442f1
