### PR TITLE
[sfputil] Make SfpUtilHelper.get_physical_to_logical noexcept as in SfpUtilBase

### DIFF
--- a/sonic_platform_base/sonic_sfp/sfputilhelper.py
+++ b/sonic_platform_base/sonic_sfp/sfputilhelper.py
@@ -123,7 +123,7 @@ class SfpUtilHelper(object):
     def get_physical_to_logical(self, port_num):
         """Returns list of logical ports for the given physical port"""
 
-        return self.physical_to_logical[port_num]
+        return self.physical_to_logical.get(port_num)
 
     def get_logical_to_physical(self, logical_port):
         """Returns list of physical ports for the given logical port"""


### PR DESCRIPTION
The SfpUtil interface used in xcvrd expects get_physical_to_logical to return None in the case of unknown port:
https://github.com/Azure/sonic-platform-daemons/blob/master/sonic-xcvrd/scripts/xcvrd#L906

Note SfpUtilBase implementation already conforms the interface in xcvrd:
https://github.com/Azure/sonic-platform-common/blob/master/sonic_platform_base/sonic_sfp/sfputilbase.py#L603