### PR TITLE
[sfp] Tweak key names of some transceiver info fields

### DIFF
--- a/sonic_platform_base/sfp_base.py
+++ b/sonic_platform_base/sfp_base.py
@@ -26,11 +26,11 @@ class SfpBase(device_base.DeviceBase):
         keys                       |Value Format   |Information	
         ---------------------------|---------------|----------------------------
         type                       |1*255VCHAR     |type of SFP
-        hardwarerev                |1*255VCHAR     |hardware version of SFP
-        serialnum                  |1*255VCHAR     |serial number of the SFP
-        manufacturename            |1*255VCHAR     |SFP vendor name
-        modelname                  |1*255VCHAR     |SFP model name
-        Connector                  |1*255VCHAR     |connector information
+        hardware_rev               |1*255VCHAR     |hardware version of SFP
+        serial                     |1*255VCHAR     |serial number of the SFP
+        manufacturer               |1*255VCHAR     |SFP vendor name
+        model                      |1*255VCHAR     |SFP model name
+        connector                  |1*255VCHAR     |connector information
         encoding                   |1*255VCHAR     |encoding information
         ext_identifier             |1*255VCHAR     |extend identifier
         ext_rateselect_compliance  |1*255VCHAR     |extended rateSelect compliance

--- a/sonic_platform_base/sfp_base.py
+++ b/sonic_platform_base/sfp_base.py
@@ -177,7 +177,7 @@ class SfpBase(device_base.DeviceBase):
         Retrieves the temperature of this SFP
 
         Returns:
-            An integer number of current temperature in Celsius
+            A float representing the current temperature in Celsius
         """
         raise NotImplementedError
 
@@ -187,7 +187,7 @@ class SfpBase(device_base.DeviceBase):
         Retrieves the supply voltage of this SFP
 
         Returns:
-            An integer number of supply voltage in mV
+            A float representing the supply voltage in mV
         """
         raise NotImplementedError
     
@@ -196,7 +196,7 @@ class SfpBase(device_base.DeviceBase):
         Retrieves the TX bias current of this SFP
 
         Returns:
-            A list of four integer numbers, representing TX bias in mA
+            A list of four floats, representing TX bias in mA
             for channel 0 to channel 4.
             Ex. ['110.09', '111.12', '108.21', '112.09']
         """
@@ -207,7 +207,7 @@ class SfpBase(device_base.DeviceBase):
         Retrieves the received optical power for this SFP
 
         Returns:
-            A list of four integer numbers, representing received optical
+            A list of four floats, representing received optical
             power in mW for channel 0 to channel 4.
             Ex. ['1.77', '1.71', '1.68', '1.70']
         """
@@ -218,7 +218,7 @@ class SfpBase(device_base.DeviceBase):
         Retrieves the TX power of this SFP
 
         Returns:
-            A list of four integer numbers, representing TX power in mW
+            A list of four floats, representing TX power in mW
             for channel 0 to channel 4.
             Ex. ['1.86', '1.86', '1.86', '1.86']
         """

--- a/sonic_platform_base/sfp_base.py
+++ b/sonic_platform_base/sfp_base.py
@@ -193,33 +193,33 @@ class SfpBase(device_base.DeviceBase):
     
     def get_tx_bias(self):
         """
-        Retrieves the TX bias current of this SFP
+        Retrieves the TX bias current of all SFP channels
 
         Returns:
-            A list of four floats, representing TX bias in mA
-            for channel 0 to channel 4.
+            A list of floats, representing TX bias in mA
+            for each available channel
             Ex. ['110.09', '111.12', '108.21', '112.09']
         """
         raise NotImplementedError
     
     def get_rx_power(self):
         """
-        Retrieves the received optical power for this SFP
+        Retrieves the received optical power of all SFP channels
 
         Returns:
-            A list of four floats, representing received optical
-            power in mW for channel 0 to channel 4.
+            A list of floats, representing received optical
+            power in mW for each available channel
             Ex. ['1.77', '1.71', '1.68', '1.70']
         """
         raise NotImplementedError
     
     def get_tx_power(self):
         """
-        Retrieves the TX power of this SFP
+        Retrieves the TX power of all SFP channels
 
         Returns:
-            A list of four floats, representing TX power in mW
-            for channel 0 to channel 4.
+            A list of floats, representing TX power in mW
+            for each available channel
             Ex. ['1.86', '1.86', '1.86', '1.86']
         """
         raise NotImplementedError

--- a/sonic_platform_base/sfp_base.py
+++ b/sonic_platform_base/sfp_base.py
@@ -115,7 +115,7 @@ class SfpBase(device_base.DeviceBase):
 
     def get_rx_los(self):
         """
-        Retrieves the RX LOS (lost-of-signal) status of SFP
+        Retrieves the RX LOS (loss-of-signal) status of SFP
 
         Returns:
             A Boolean, True if SFP has RX LOS, False if not.

--- a/sonic_platform_base/sonic_sfp/sfputilbase.py
+++ b/sonic_platform_base/sonic_sfp/sfputilbase.py
@@ -817,14 +817,14 @@ class SfpUtilBase(object):
 
             transceiver_info_dict['type'] = sfp_type_data['data']['type']['value']
             transceiver_info_dict['type_abbrv_name'] = sfp_type_abbrv_name['data']['type_abbrv_name']['value']
-            transceiver_info_dict['manufacturename'] = sfp_vendor_name_data['data']['Vendor Name']['value']
-            transceiver_info_dict['modelname'] = sfp_vendor_pn_data['data']['Vendor PN']['value']
-            transceiver_info_dict['hardwarerev'] = sfp_vendor_rev_data['data']['Vendor Rev']['value']
-            transceiver_info_dict['serialnum'] = sfp_vendor_sn_data['data']['Vendor SN']['value']
+            transceiver_info_dict['manufacturer'] = sfp_vendor_name_data['data']['Vendor Name']['value']
+            transceiver_info_dict['model'] = sfp_vendor_pn_data['data']['Vendor PN']['value']
+            transceiver_info_dict['hardware_rev'] = sfp_vendor_rev_data['data']['Vendor Rev']['value']
+            transceiver_info_dict['serial'] = sfp_vendor_sn_data['data']['Vendor SN']['value']
             # Below part is added to avoid fail the xcvrd, shall be implemented later
             transceiver_info_dict['vendor_oui'] = 'N/A'
             transceiver_info_dict['vendor_date'] = 'N/A'
-            transceiver_info_dict['Connector'] = 'N/A'
+            transceiver_info_dict['connector'] = 'N/A'
             transceiver_info_dict['encoding'] = 'N/A'
             transceiver_info_dict['ext_identifier'] = 'N/A'
             transceiver_info_dict['ext_rateselect_compliance'] = 'N/A'
@@ -926,13 +926,13 @@ class SfpUtilBase(object):
 
             transceiver_info_dict['type'] = sfp_interface_bulk_data['data']['type']['value']
             transceiver_info_dict['type_abbrv_name'] = sfp_interface_bulk_data['data']['type_abbrv_name']['value']
-            transceiver_info_dict['manufacturename'] = sfp_vendor_name_data['data']['Vendor Name']['value']
-            transceiver_info_dict['modelname'] = sfp_vendor_pn_data['data']['Vendor PN']['value']
-            transceiver_info_dict['hardwarerev'] = sfp_vendor_rev_data['data']['Vendor Rev']['value']
-            transceiver_info_dict['serialnum'] = sfp_vendor_sn_data['data']['Vendor SN']['value']
+            transceiver_info_dict['manufacturer'] = sfp_vendor_name_data['data']['Vendor Name']['value']
+            transceiver_info_dict['model'] = sfp_vendor_pn_data['data']['Vendor PN']['value']
+            transceiver_info_dict['hardware_rev'] = sfp_vendor_rev_data['data']['Vendor Rev']['value']
+            transceiver_info_dict['serial'] = sfp_vendor_sn_data['data']['Vendor SN']['value']
             transceiver_info_dict['vendor_oui'] = sfp_vendor_oui_data['data']['Vendor OUI']['value']
             transceiver_info_dict['vendor_date'] = sfp_vendor_date_data['data']['VendorDataCode(YYYY-MM-DD Lot)']['value']
-            transceiver_info_dict['Connector'] = sfp_interface_bulk_data['data']['Connector']['value']
+            transceiver_info_dict['connector'] = sfp_interface_bulk_data['data']['Connector']['value']
             transceiver_info_dict['encoding'] = sfp_interface_bulk_data['data']['EncodingCodes']['value']
             transceiver_info_dict['ext_identifier'] = sfp_interface_bulk_data['data']['Extended Identifier']['value']
             transceiver_info_dict['ext_rateselect_compliance'] = sfp_interface_bulk_data['data']['RateIdentifier']['value']


### PR DESCRIPTION
Change the following key names:

- hardwarerev -> hardware_rev
- serialnum -> serial
- manufacturename -> manufacturer
- modelname -> model
- Connector -> connector

Also fix a typo and some return types in docstrings