### PR TITLE
Sfputil base and helper class changes for multi-ASIC

### DIFF
--- a/sonic_platform_base/sonic_sfp/sfputilbase.py
+++ b/sonic_platform_base/sonic_sfp/sfputilbase.py
@@ -16,6 +16,7 @@ try:
     from natsort import natsorted
     from portconfig import get_port_config
     from sonic_py_common import device_info
+    from sonic_py_common.interface import backplane_prefix
 
     from . import bcmshell       # Dot module supports both Python 2 and Python 3 using explicit relative import methods
     from sonic_eeprom import eeprom_dts
@@ -459,7 +460,7 @@ class SfpUtilBase(object):
                 portname = line.split()[0]
 
                 # Ignore if this is an internal backplane interface
-                if portname.startswith(daemon_base.get_internal_interface_prefix()):
+                if portname.startswith(backplane_prefix()):
                     continue
 
                 bcm_port = str(port_pos_in_file)
@@ -640,10 +641,7 @@ class SfpUtilBase(object):
 
     def get_asic_id_for_logical_port(self, logical_port):
         """Returns the asic_id list of physical ports for the given logical port"""
-        if logical_port in self.logical_to_asic.keys():
-            return self.logical_to_asic[logical_port]
-        else:
-            return None
+        return self.logical_to_asic.get(logical_port)
 
     def is_logical_port_ganged_40_by_4(self, logical_port):
         physical_port_list = self.logical_to_physical[logical_port]

--- a/sonic_platform_base/sonic_sfp/sfputilbase.py
+++ b/sonic_platform_base/sonic_sfp/sfputilbase.py
@@ -31,6 +31,9 @@ except ImportError as e:
 PLATFORM_JSON = 'platform.json'
 PORT_CONFIG_INI = 'port_config.ini'
 
+# TODO, to move this definition to a common place
+INTERNAL_INTERFACE_PREFIX = "Ethernet-BP"
+
 # definitions of the offset and width for values in XCVR info eeprom
 XCVR_INTFACE_BULK_OFFSET = 0
 XCVR_INTFACE_BULK_WIDTH_QSFP = 20
@@ -156,6 +159,9 @@ class SfpUtilBase(object):
     # List of logical port names available on a system
     """ ["swp1", "swp5", "swp6", "swp7", "swp8" ...] """
     logical = []
+
+    # Mapping of logical port names available on a system to ASIC num
+    logical_to_asic = {}
 
     # dicts for easier conversions between logical, physical and bcm ports
     logical_to_bcm = {}
@@ -371,7 +377,7 @@ class SfpUtilBase(object):
 
         return False
 
-    def read_porttab_mappings(self, porttabfile):
+    def read_porttab_mappings(self, porttabfile, asic_inst = 0):
         logical = []
         logical_to_bcm = {}
         logical_to_physical = {}
@@ -455,12 +461,16 @@ class SfpUtilBase(object):
                 # so we use the port's position in the file (zero-based) as bcm_port
                 portname = line.split()[0]
 
+                # Ignore if this is an internal backplane interface
+                if portname.startswith(INTERNAL_INTERFACE_PREFIX):
+                    continue
+
                 bcm_port = str(port_pos_in_file)
 
                 if "index" in title:
                     fp_port_index = int(line.split()[title.index("index")])
                 # Leave the old code for backward compatibility
-                elif len(line.split()) >= 4:
+                elif "asic_port_name" not in title and len(line.split()) >= 4:
                     fp_port_index = int(line.split()[3])
                 else:
                     fp_port_index = portname.split("Ethernet").pop()
@@ -483,6 +493,9 @@ class SfpUtilBase(object):
 
             logical.append(portname)
 
+            # Mapping of logical port names available on a system to ASIC instance
+            self.logical_to_asic[portname] = asic_inst
+
             logical_to_bcm[portname] = "xe" + bcm_port
             logical_to_physical[portname] = [fp_port_index]
             if physical_to_logical.get(fp_port_index) is None:
@@ -495,10 +508,10 @@ class SfpUtilBase(object):
 
             port_pos_in_file += 1
 
-        self.logical = logical
-        self.logical_to_bcm = logical_to_bcm
-        self.logical_to_physical = logical_to_physical
-        self.physical_to_logical = physical_to_logical
+        self.logical.extend(logical)
+        self.logical_to_bcm.update(logical_to_bcm)
+        self.logical_to_physical.update(logical_to_physical)
+        self.physical_to_logical.update(physical_to_logical)
 
         """
         print("logical: " + self.logical)
@@ -506,6 +519,18 @@ class SfpUtilBase(object):
         print("logical to physical: " + self.logical_to_physical)
         print("physical to logical: " + self.physical_to_logical)
         """
+
+    def read_all_porttab_mappings(self, platform_dir, num_asic_inst):
+        # In multi asic scenario, get all the port_config files for different asics
+         for inst in range(num_asic_inst):
+             port_map_dir = os.path.join(platform_dir, str(inst))
+             port_map_file = os.path.join(port_map_dir, PORT_CONFIG_INI)
+             if os.path.exists(port_map_file):
+                 self.read_porttab_mappings(port_map_file, inst)
+             else:
+                 port_json_file = os.path.join(port_map_dir, PLATFORM_JSON)
+                 self.read_porttab_mappings(port_json_file, inst)
+
     def read_phytab_mappings(self, phytabfile):
         logical = []
         phytab_mappings = {}
@@ -614,6 +639,13 @@ class SfpUtilBase(object):
             return 1
         else:
             return 0
+
+    def get_asicId_for_logical_port(self, logical_port):
+        """Returns the asic_id list of physical ports for the given logical port"""
+        if logical_port in self.logical_to_asic.keys():
+            return self.logical_to_asic[logical_port]
+        else:
+            return None
 
     def is_logical_port_ganged_40_by_4(self, logical_port):
         physical_port_list = self.logical_to_physical[logical_port]

--- a/sonic_platform_base/sonic_sfp/sfputilbase.py
+++ b/sonic_platform_base/sonic_sfp/sfputilbase.py
@@ -31,9 +31,6 @@ except ImportError as e:
 PLATFORM_JSON = 'platform.json'
 PORT_CONFIG_INI = 'port_config.ini'
 
-# TODO, to move this definition to a common place
-INTERNAL_INTERFACE_PREFIX = "Ethernet-BP"
-
 # definitions of the offset and width for values in XCVR info eeprom
 XCVR_INTFACE_BULK_OFFSET = 0
 XCVR_INTFACE_BULK_WIDTH_QSFP = 20
@@ -462,7 +459,7 @@ class SfpUtilBase(object):
                 portname = line.split()[0]
 
                 # Ignore if this is an internal backplane interface
-                if portname.startswith(INTERNAL_INTERFACE_PREFIX):
+                if portname.startswith(daemon_base.get_internal_interface_prefix()):
                     continue
 
                 bcm_port = str(port_pos_in_file)
@@ -529,7 +526,8 @@ class SfpUtilBase(object):
                  self.read_porttab_mappings(port_map_file, inst)
              else:
                  port_json_file = os.path.join(port_map_dir, PLATFORM_JSON)
-                 self.read_porttab_mappings(port_json_file, inst)
+                 if os.path.exists(port_json_file):
+                     self.read_porttab_mappings(port_json_file, inst)
 
     def read_phytab_mappings(self, phytabfile):
         logical = []

--- a/sonic_platform_base/sonic_sfp/sfputilbase.py
+++ b/sonic_platform_base/sonic_sfp/sfputilbase.py
@@ -374,7 +374,7 @@ class SfpUtilBase(object):
 
         return False
 
-    def read_porttab_mappings(self, porttabfile, asic_inst = 0):
+    def read_porttab_mappings(self, porttabfile, asic_inst=0):
         logical = []
         logical_to_bcm = {}
         logical_to_physical = {}
@@ -638,7 +638,7 @@ class SfpUtilBase(object):
         else:
             return 0
 
-    def get_asicId_for_logical_port(self, logical_port):
+    def get_asic_id_for_logical_port(self, logical_port):
         """Returns the asic_id list of physical ports for the given logical port"""
         if logical_port in self.logical_to_asic.keys():
             return self.logical_to_asic[logical_port]

--- a/sonic_platform_base/sonic_sfp/sfputilhelper.py
+++ b/sonic_platform_base/sonic_sfp/sfputilhelper.py
@@ -23,9 +23,6 @@ except ImportError as e:
 PLATFORM_JSON = 'platform.json'
 PORT_CONFIG_INI = 'port_config.ini'
 
-# TODO, to move this definition to a common place
-INTERNAL_INTERFACE_PREFIX = "Ethernet-BP"
-
 class SfpUtilHelper(object):
     # List to specify filter for sfp_ports
     # Needed by platforms like dni-6448 which
@@ -129,7 +126,7 @@ class SfpUtilHelper(object):
                 portname = line.split()[0]
 
                 # Ignore if this is an internal backplane interface
-                if portname.startswith(INTERNAL_INTERFACE_PREFIX):
+                if portname.startswith(daemon_base.get_internal_interface_prefix()):
                     continue
 
                 bcm_port = str(port_pos_in_file)
@@ -186,15 +183,15 @@ class SfpUtilHelper(object):
 
     def read_all_porttab_mappings(self, platform_dir, num_asic_inst):
         # In multi asic scenario, get all the port_config files for different asics
-
          for inst in range(num_asic_inst):
-             port_map_dir = os.path.join(platform_dir, str(inst), '/')
-             port_map_file = os.path.join(port_map_dir, str(inst), PORT_CONFIG_INI)
+             port_map_dir = os.path.join(platform_dir, str(inst))
+             port_map_file = os.path.join(port_map_dir, PORT_CONFIG_INI)
              if os.path.exists(port_map_file):
                  self.read_porttab_mappings(port_map_file, inst)
              else:
-                 port_json_file = os.path.join(port_map_dir, str(inst), PLATFORM_JSON)
-                 self.read_porttab_mappings(port_json_file, inst)
+                 port_json_file = os.path.join(port_map_dir, PLATFORM_JSON)
+                 if os.path.exists(port_json_file):
+                     self.read_porttab_mappings(port_json_file, inst)
 
     def get_physical_to_logical(self, port_num):
         """Returns list of logical ports for the given physical port"""

--- a/sonic_platform_base/sonic_sfp/sfputilhelper.py
+++ b/sonic_platform_base/sonic_sfp/sfputilhelper.py
@@ -209,7 +209,7 @@ class SfpUtilHelper(object):
         else:
             return 0
 
-    def get_asicId_for_logical_port(self, logical_port):
+    def get_asic_id_for_logical_port(self, logical_port):
         """Returns the asic_id list of physical ports for the given logical port"""
         if logical_port in self.logical_to_asic.keys():
             return self.logical_to_asic[logical_port]

--- a/sonic_platform_base/sonic_sfp/sfputilhelper.py
+++ b/sonic_platform_base/sonic_sfp/sfputilhelper.py
@@ -45,7 +45,7 @@ class SfpUtilHelper(object):
     def __init__(self):
         pass
 
-    def read_porttab_mappings(self, porttabfile, asic_inst = 0):
+    def read_porttab_mappings(self, porttabfile, asic_inst=0):
         logical = []
         logical_to_physical = {}
         physical_to_logical = {}

--- a/sonic_platform_base/sonic_sfp/sfputilhelper.py
+++ b/sonic_platform_base/sonic_sfp/sfputilhelper.py
@@ -23,6 +23,9 @@ except ImportError as e:
 PLATFORM_JSON = 'platform.json'
 PORT_CONFIG_INI = 'port_config.ini'
 
+# TODO, to move this definition to a common place
+INTERNAL_INTERFACE_PREFIX = "Ethernet-BP"
+
 class SfpUtilHelper(object):
     # List to specify filter for sfp_ports
     # Needed by platforms like dni-6448 which
@@ -33,6 +36,9 @@ class SfpUtilHelper(object):
     """ ["swp1", "swp5", "swp6", "swp7", "swp8" ...] """
     logical = []
 
+    # Mapping of logical port names available on a system to ASIC num
+    logical_to_asic = {}
+
     # dicts for easier conversions between logical, physical and bcm ports
     logical_to_physical = {}
 
@@ -42,7 +48,7 @@ class SfpUtilHelper(object):
     def __init__(self):
         pass
 
-    def read_porttab_mappings(self, porttabfile):
+    def read_porttab_mappings(self, porttabfile, asic_inst = 0):
         logical = []
         logical_to_physical = {}
         physical_to_logical = {}
@@ -122,12 +128,16 @@ class SfpUtilHelper(object):
                 # so we use the port's position in the file (zero-based) as bcm_port
                 portname = line.split()[0]
 
+                # Ignore if this is an internal backplane interface
+                if portname.startswith(INTERNAL_INTERFACE_PREFIX):
+                    continue
+
                 bcm_port = str(port_pos_in_file)
 
                 if "index" in title:
                     fp_port_index = int(line.split()[title.index("index")])
                 # Leave the old code for backward compatibility
-                elif len(line.split()) >= 4:
+                elif "asic_port_name" not in title and len(line.split()) >= 4:
                     fp_port_index = int(line.split()[3])
                 else:
                     fp_port_index = portname.split("Ethernet").pop()
@@ -150,6 +160,9 @@ class SfpUtilHelper(object):
 
             logical.append(portname)
 
+            # Mapping of logical port names available on a system to ASIC instance
+            self.logical_to_asic[portname] = asic_inst
+
             logical_to_physical[portname] = [fp_port_index]
             if physical_to_logical.get(fp_port_index) is None:
                 physical_to_logical[fp_port_index] = [portname]
@@ -161,15 +174,28 @@ class SfpUtilHelper(object):
 
             port_pos_in_file += 1
 
-        self.logical = logical
-        self.logical_to_physical = logical_to_physical
-        self.physical_to_logical = physical_to_logical
+        self.logical.extend(logical)
+        self.logical_to_physical.update(logical_to_physical)
+        self.physical_to_logical.update(physical_to_logical)
 
         """
         print("logical: " + self.logical)
         print("logical to physical: " + self.logical_to_physical)
         print("physical to logical: " + self.physical_to_logical)
         """
+
+    def read_all_porttab_mappings(self, platform_dir, num_asic_inst):
+        # In multi asic scenario, get all the port_config files for different asics
+
+         for inst in range(num_asic_inst):
+             port_map_dir = os.path.join(platform_dir, str(inst), '/')
+             port_map_file = os.path.join(port_map_dir, str(inst), PORT_CONFIG_INI)
+             if os.path.exists(port_map_file):
+                 self.read_porttab_mappings(port_map_file, inst)
+             else:
+                 port_json_file = os.path.join(port_map_dir, str(inst), PLATFORM_JSON)
+                 self.read_porttab_mappings(port_json_file, inst)
+
     def get_physical_to_logical(self, port_num):
         """Returns list of logical ports for the given physical port"""
 
@@ -185,3 +211,10 @@ class SfpUtilHelper(object):
             return 1
         else:
             return 0
+
+    def get_asicId_for_logical_port(self, logical_port):
+        """Returns the asic_id list of physical ports for the given logical port"""
+        if logical_port in self.logical_to_asic.keys():
+            return self.logical_to_asic[logical_port]
+        else:
+            return None

--- a/sonic_platform_base/sonic_sfp/sfputilhelper.py
+++ b/sonic_platform_base/sonic_sfp/sfputilhelper.py
@@ -16,6 +16,8 @@ try:
     from natsort import natsorted
     from portconfig import get_port_config
     from sonic_py_common import device_info
+    from sonic_py_common.interface import backplane_prefix
+
 except ImportError as e:
     raise ImportError("%s - required module not found" % str(e))
 
@@ -126,7 +128,7 @@ class SfpUtilHelper(object):
                 portname = line.split()[0]
 
                 # Ignore if this is an internal backplane interface
-                if portname.startswith(daemon_base.get_internal_interface_prefix()):
+                if portname.startswith(backplane_prefix()):
                     continue
 
                 bcm_port = str(port_pos_in_file)
@@ -211,7 +213,4 @@ class SfpUtilHelper(object):
 
     def get_asic_id_for_logical_port(self, logical_port):
         """Returns the asic_id list of physical ports for the given logical port"""
-        if logical_port in self.logical_to_asic.keys():
-            return self.logical_to_asic[logical_port]
-        else:
-            return None
+        return self.logical_to_asic.get(logical_port)


### PR DESCRIPTION
This is for changes needed to support multi-asic platforms. 
(i) Add a new API to parse the port_config.ini files in different directories named based on the asic_ID's 
(ii) Add a new dictionary which maps the interface to the asic_id 
(iii) Check if it is a backplane interface, if so skip from adding it to logical_port list