### PR TITLE
[sfp] Add parsing the dom_capability to sff8472

### DIFF
--- a/sonic_platform_base/sonic_sfp/sff8436.py
+++ b/sonic_platform_base/sonic_sfp/sff8436.py
@@ -508,14 +508,14 @@ class sff8436InterfaceId(sffbase):
 
     def parse_vendor_date(self, sn_raw_data, start_pos):
         return sffbase.parse(self, self.vendor_date, sn_raw_data, start_pos)
-    
+
     def parse_vendor_oui(self, sn_raw_data, start_pos):
         return sffbase.parse(self, self.vendor_oui, sn_raw_data, start_pos)
 
     def parse_ext_specification_compliance(self, sn_raw_data, start_pos):
         return sffbase.parse(self, self.sfp_ext_specification_compliance, sn_raw_data, start_pos)
 
-    def parse_qsfp_dom_capability(self, sn_raw_data, start_pos):
+    def parse_dom_capability(self, sn_raw_data, start_pos):
         return sffbase.parse(self, self.qsfp_dom_capability, sn_raw_data, start_pos)
 
     def dump_pretty(self):

--- a/sonic_platform_base/sonic_sfp/sff8472.py
+++ b/sonic_platform_base/sonic_sfp/sff8472.py
@@ -521,6 +521,13 @@ class sff8472InterfaceId(sffbase):
             'type': 'date'}
         }
 
+    sfp_dom_capability = {
+        'sff8472_dom_support':
+            {'offset': 0,
+             'bit': 6,
+             'type': 'bitvalue'}
+        }
+
     # Returns calibration type
     def _get_calibration_type(self, eeprom_data):
         try:
@@ -569,6 +576,9 @@ class sff8472InterfaceId(sffbase):
 
     def parse_vendor_oui(self, sn_raw_data, start_pos):
         return sffbase.parse(self, self.vendor_oui, sn_raw_data, start_pos)
+
+    def parse_dom_capability(self, dom_type_raw_data, start_pos):
+        return sffbase.parse(self, self.sfp_dom_capability, dom_type_raw_data, start_pos)
 
     def dump_pretty(self):
         if self.interface_data == None:

--- a/sonic_platform_base/sonic_sfp/sfputilbase.py
+++ b/sonic_platform_base/sonic_sfp/sfputilbase.py
@@ -123,6 +123,12 @@ qsfp_compliance_code_tup = ('10/40G Ethernet Compliance Code', 'SONET Compliance
                             'Fibre Channel link length/Transmitter Technology',
                             'Fibre Channel transmission media', 'Fibre Channel Speed')
 
+qsfp_dom_capability_tup = ('Tx_power_support', 'Rx_power_support',
+                           'Voltage_support', 'Temp_support')
+
+# Add an EOL to prevent this being viewed as string instead of list
+sfp_dom_capability_tup = ('sff8472_dom_support', 'EOL')
+
 class SfpUtilError(Exception):
     """Base class for exceptions in this module."""
     pass
@@ -751,6 +757,7 @@ class SfpUtilBase(object):
     def get_transceiver_info_dict(self, port_num):
         transceiver_info_dict = {}
         compliance_code_dict = {}
+        dom_capability_dict = {}
 
         # ToDo: OSFP tranceiver info parsing not fully supported.
         # in inf8628.py lack of some memory map definition
@@ -835,6 +842,7 @@ class SfpUtilBase(object):
             transceiver_info_dict['specification_compliance'] = '{}'
             transceiver_info_dict['nominal_bit_rate'] = 'N/A'
             transceiver_info_dict['application_advertisement'] = 'N/A'
+            transceiver_info_dict['dom_capability'] = '{}'
 
         else:
             file_path = self._get_port_eeprom_path(port_num, self.IDENTITY_EEPROM_ADDR)
@@ -921,6 +929,12 @@ class SfpUtilBase(object):
             else:
                 return None
 
+            sfp_dom_capability_raw = self._read_eeprom_specific_bytes(sysfsfile_eeprom, (offset + XCVR_DOM_CAPABILITY_OFFSET), XCVR_DOM_CAPABILITY_WIDTH)
+            if sfp_dom_capability_raw is not None:
+                sfp_dom_capability_data = sfpi_obj.parse_dom_capability(sfp_dom_capability_raw, 0)
+            else:
+                return None
+
             try:
                 sysfsfile_eeprom.close()
             except IOError:
@@ -954,6 +968,11 @@ class SfpUtilBase(object):
                         compliance_code_dict[key] = sfp_interface_bulk_data['data']['Specification compliance']['value'][key]['value']
                 transceiver_info_dict['specification_compliance'] = str(compliance_code_dict)
 
+                for key in qsfp_dom_capability_tup:
+                    if key in sfp_dom_capability_data['data']:
+                        dom_capability_dict[key] = "yes" if sfp_dom_capability_data['data'][key]['value'] == 'on' else "no"
+                transceiver_info_dict['dom_capability'] = str(dom_capability_dict)
+
                 transceiver_info_dict['nominal_bit_rate'] = str(sfp_interface_bulk_data['data']['Nominal Bit Rate(100Mbs)']['value'])
             else:
                 for key in sfp_cable_length_tup:
@@ -965,6 +984,11 @@ class SfpUtilBase(object):
                     if key in sfp_interface_bulk_data['data']['Specification compliance']['value']:
                         compliance_code_dict[key] = sfp_interface_bulk_data['data']['Specification compliance']['value'][key]['value']
                 transceiver_info_dict['specification_compliance'] = str(compliance_code_dict)
+
+                for key in sfp_dom_capability_tup:
+                    if key in sfp_dom_capability_data['data']:
+                        dom_capability_dict[key] = "yes" if sfp_dom_capability_data['data'][key]['value'] == 'on' else "no"
+                transceiver_info_dict['dom_capability'] = str(dom_capability_dict)
 
                 transceiver_info_dict['nominal_bit_rate'] = str(sfp_interface_bulk_data['data']['NominalSignallingRate(UnitsOf100Mbd)']['value'])
 
@@ -1025,7 +1049,7 @@ class SfpUtilBase(object):
             # in SFF-8636 dom capability definitions evolving with the versions.
             qsfp_dom_capability_raw = self._read_eeprom_specific_bytes(sysfsfile_eeprom, (offset_xcvr + XCVR_DOM_CAPABILITY_OFFSET), XCVR_DOM_CAPABILITY_WIDTH)
             if qsfp_dom_capability_raw is not None:
-                qspf_dom_capability_data = sfpi_obj.parse_qsfp_dom_capability(qsfp_dom_capability_raw, 0)
+                qspf_dom_capability_data = sfpi_obj.parse_dom_capability(qsfp_dom_capability_raw, 0)
             else:
                 return None
 


### PR DESCRIPTION
- What I did
Following SFF-8472 to read diagnostic monitoring type register.
Use that register to check if diagnostic monitoring function implemented or not.

- How I did it
Check the register position from SFF-8472 document.
Read the register value from the EEPROM.

- How to verify it
Compare one transceiver which support diagnostic monitoring function to another transceiver which doesn't support it.
Run 'show interfaces transceiver eeprom' command.