### PR TITLE
Migrate from sonic-daemon-base package to sonic-py-common package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
         'sonic_thermal',
     ],
     install_requires=[
-        'sonic-config-engine',
+        'sonic-config-engine',  # For portconfig
         'sonic-py-common'
     ],
     classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,7 @@ setup(
         'sonic_thermal',
     ],
     install_requires=[
+        'sonic-config-engine',
         'sonic-py-common'
     ],
     classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
         'sonic_thermal',
     ],
     install_requires=[
-        'sonic-config-engine',  # For portconfig
+        'sonic-config-engine',  # For portconfig. TODO: Remove this dependency
         'sonic-py-common'
     ],
     classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,9 @@ setup(
         'sonic_sfp',
         'sonic_thermal',
     ],
+    install_requires=[
+        'sonic-py-common'
+    ],
     classifiers=[
         'Development Status :: 3 - Alpha',
         'Environment :: Plugins',

--- a/sonic_platform_base/sonic_sfp/sfputilbase.py
+++ b/sonic_platform_base/sonic_sfp/sfputilbase.py
@@ -15,7 +15,7 @@ try:
 
     from natsort import natsorted
     from portconfig import get_port_config
-    from sonic_py_common.daemon_base import DaemonBase
+    from sonic_py_common import device_info
 
     from . import bcmshell       # Dot module supports both Python 2 and Python 3 using explicit relative import methods
     from sonic_eeprom import eeprom_dts
@@ -386,7 +386,7 @@ class SfpUtilBase(object):
         parse_fmt_port_config_ini = (os.path.basename(porttabfile) == PORT_CONFIG_INI)
         parse_fmt_platform_json = (os.path.basename(porttabfile) == PLATFORM_JSON)
 
-        (platform, hwsku) =  DaemonBase().get_platform_and_hwsku()
+        (platform, hwsku) = device_info.get_platform_and_hwsku()
         if(parse_fmt_platform_json):
             ports, _ = get_port_config(hwsku, platform)
             if not ports:

--- a/sonic_platform_base/sonic_sfp/sfputilbase.py
+++ b/sonic_platform_base/sonic_sfp/sfputilbase.py
@@ -10,6 +10,13 @@ try:
     import binascii
     import os
     import re
+    import sys
+    from collections import OrderedDict
+
+    from natsort import natsorted
+    from portconfig import get_port_config
+    from sonic_py_common.daemon_base import DaemonBase
+
     from . import bcmshell       # Dot module supports both Python 2 and Python 3 using explicit relative import methods
     from sonic_eeprom import eeprom_dts
     from .sff8472 import sff8472InterfaceId  # Dot module supports both Python 2 and Python 3 using explicit relative import methods
@@ -17,11 +24,6 @@ try:
     from .sff8436 import sff8436InterfaceId  # Dot module supports both Python 2 and Python 3 using explicit relative import methods
     from .sff8436 import sff8436Dom    # Dot module supports both Python 2 and Python 3 using explicit relative import methods
     from .inf8628 import inf8628InterfaceId    # Dot module supports both Python 2 and Python 3 using explicit relative import methods
-    from portconfig import get_port_config
-    from collections import OrderedDict
-    from natsort import natsorted
-    from sonic_daemon_base.daemon_base import DaemonBase
-    import sys
 except ImportError as e:
     raise ImportError("%s - required module not found" % str(e))
 

--- a/sonic_platform_base/sonic_sfp/sfputilhelper.py
+++ b/sonic_platform_base/sonic_sfp/sfputilhelper.py
@@ -15,7 +15,7 @@ try:
 
     from natsort import natsorted
     from portconfig import get_port_config
-    from sonic_py_common.daemon_base import DaemonBase
+    from sonic_py_common import device_info
 except ImportError as e:
     raise ImportError("%s - required module not found" % str(e))
 
@@ -56,7 +56,7 @@ class SfpUtilHelper(object):
         parse_fmt_port_config_ini = (os.path.basename(porttabfile) == PORT_CONFIG_INI)
         parse_fmt_platform_json = (os.path.basename(porttabfile) == PLATFORM_JSON)
 
-        (platform, hwsku) =  DaemonBase().get_platform_and_hwsku()
+        (platform, hwsku) = device_info.get_platform_and_hwsku()
         if(parse_fmt_platform_json):
             ports, _ = get_port_config(hwsku, platform)
             if not ports:

--- a/sonic_platform_base/sonic_sfp/sfputilhelper.py
+++ b/sonic_platform_base/sonic_sfp/sfputilhelper.py
@@ -10,11 +10,12 @@ try:
     import binascii
     import os
     import re
-    from portconfig import get_port_config
-    from collections import OrderedDict
-    from natsort import natsorted
-    from sonic_daemon_base.daemon_base import DaemonBase
     import sys
+    from collections import OrderedDict
+
+    from natsort import natsorted
+    from portconfig import get_port_config
+    from sonic_py_common.daemon_base import DaemonBase
 except ImportError as e:
     raise ImportError("%s - required module not found" % str(e))
 


### PR DESCRIPTION
As part of consolidating all common Python-based functionality into the new sonic-py-common package, this pull request migrates from importing the sonic-daemon-base package to importing the sonic-py-common package. This is the next step toward resolving https://github.com/Azure/sonic-buildimage/issues/4999.

- Also reorganize imports for consistency 