### PR TITLE
[sfputilbase.py] Add application_advertisement N/A field to transceiver_info_dict for platform api 1.0

### DIFF
--- a/sonic_platform_base/sonic_sfp/sfputilbase.py
+++ b/sonic_platform_base/sonic_sfp/sfputilbase.py
@@ -832,6 +832,7 @@ class SfpUtilBase(object):
             transceiver_info_dict['cable_length'] = 'N/A'
             transceiver_info_dict['specification_compliance'] = '{}'
             transceiver_info_dict['nominal_bit_rate'] = 'N/A'
+            transceiver_info_dict['application_advertisement'] = 'N/A'
 
         else:
             file_path = self._get_port_eeprom_path(port_num, self.IDENTITY_EEPROM_ADDR)
@@ -938,6 +939,8 @@ class SfpUtilBase(object):
             transceiver_info_dict['ext_rateselect_compliance'] = sfp_interface_bulk_data['data']['RateIdentifier']['value']
             transceiver_info_dict['cable_type'] = "Unknown"
             transceiver_info_dict['cable_length'] = "Unknown"
+            transceiver_info_dict['application_advertisement'] = 'N/A'
+
             if sfp_type == 'QSFP':
                 for key in qsfp_cable_length_tup:
                     if key in sfp_interface_bulk_data['data']:


### PR DESCRIPTION
Signed-off-by: Volodymyr Boyko <volodymyrx.boiko@intel.com>

Fixes the following bug reproduced on SONiC.HEAD.729-dirty-20200727.075328:
```
pmon#supervisord: xcvrd Traceback (most recent call last):
INFO pmon#supervisord: xcvrd   File "/usr/bin/xcvrd", line 1207, in <module>
INFO pmon#supervisord: xcvrd     main()
INFO pmon#supervisord: xcvrd   File "/usr/bin/xcvrd", line 1204, in main
INFO pmon#supervisord: xcvrd     xcvrd.run()
INFO pmon#supervisord: xcvrd   File "/usr/bin/xcvrd", line 1165, in run
INFO pmon#supervisord: xcvrd     self.init()
INFO pmon#supervisord: xcvrd   File "/usr/bin/xcvrd", line 1144, in init
INFO pmon#supervisord: xcvrd     post_port_sfp_dom_info_to_db(is_warm_start, self.stop_event)
INFO pmon#supervisord: xcvrd   File "/usr/bin/xcvrd", line 430, in post_port_sfp_dom_info_to_db
INFO pmon#supervisord: xcvrd     post_port_sfp_info_to_db(logical_port_name, int_tbl, transceiver_dict, stop_event)
INFO pmon#supervisord: xcvrd   File "/usr/bin/xcvrd", line 260, in post_port_sfp_info_to_db
INFO pmon#supervisord: xcvrd     ('application_advertisement',port_info_dict['application_advertisement'])])
INFO pmon#supervisord: xcvrd KeyError: 'application_advertisement'
```