### PR TITLE
[component] add auto_update_firmware() to support the auto update.

### DIFF
--- a/sonic_platform_base/component_base.py
+++ b/sonic_platform_base/component_base.py
@@ -88,7 +88,7 @@ class ComponentBase(object):
         """
         raise NotImplementedError
 
-    def update_firmware(self, image_path):
+    def update_firmware(self, image_path, boot_action):
         """
         Updates firmware of the component
 
@@ -98,6 +98,7 @@ class ComponentBase(object):
 
         Args:
             image_path: A string, path to firmware image
+            boot_action: A string, boot action following the upgrade
 
         Raises:
             RuntimeError: update failed

--- a/sonic_platform_base/component_base.py
+++ b/sonic_platform_base/component_base.py
@@ -120,11 +120,16 @@ class ComponentBase(object):
                          - none/fast/warm/cold
 
         Returns:
-            Output: A string, status and info
-                status: True or False, firmware auto-update status
-                info: The detail information of the firmware auto-update status.
-                      - "updated"/"installed"(which needs a reboot for the firmware to be active)/"scheduled"
-                      - "ns_boot_type/image_error/exec_fail"
+            Output: A return code
+                return_code: An integer number, status of component firmware auto-update
+                    - return code of a positive number indicates successful auto-update
+                        - status_installed = 1
+                        - status_updated = 2
+                        - status_scheduled = 3
+                    - return_code of a negative number indicates failed auto-update
+                        - status_err_boot_type = -1
+                        - status_err_image = -2
+                        - status_err_others = -3
 
         Raises:
             RuntimeError: auto-update failure cause

--- a/sonic_platform_base/component_base.py
+++ b/sonic_platform_base/component_base.py
@@ -104,22 +104,21 @@ class ComponentBase(object):
         """
         raise NotImplementedError
 
-    def auto_update_firmware(self, image_path, boot_action, command):
+    def auto_update_firmware(self, image_path, boot_action):
         """
         Updates firmware of the component
 
         This API performs firmware update automatically based on boot_action: it assumes firmware installation 
-        and creating a loading task in a single call.
+        and/or creating a loading task during a boot action, if needed, in a single call.
         In case platform component requires some extra steps (apart from calling Low Level Utility)
         to load the installed firmware (e.g, reboot, power cycle, etc.) - this will be done automatically during the reboot.
-        The loading task will be created by API and it will be performed by the reboot script.
+        The loading task will be created by API.
 
         Args:
             image_path: A string, path to firmware image
             boot_action: A string, boot action following the upgrade
-            command: A string, command to be performed
 
         Raises:
-            RuntimeError: update failed
+            RuntimeError: auto-update failure cause
         """
         raise NotImplementedError

--- a/sonic_platform_base/component_base.py
+++ b/sonic_platform_base/component_base.py
@@ -129,7 +129,7 @@ class ComponentBase(object):
                     - return_code of a negative number indicates failed auto-update
                         - status_err_boot_type = -1
                         - status_err_image = -2
-                        - status_err_others = -3
+                        - status_err_unknown = -3
 
         Raises:
             RuntimeError: auto-update failure cause

--- a/sonic_platform_base/component_base.py
+++ b/sonic_platform_base/component_base.py
@@ -117,12 +117,14 @@ class ComponentBase(object):
         Args:
             image_path: A string, path to firmware image
             boot_action: A string, boot action following the upgrade
+                         - none/fast/warm/cold
 
         Returns:
             Output: A string, status and info
                 status: True or False, firmware auto-update status
                 info: The detail information of the firmware auto-update status.
-                    "updated"/"installed"(which needs a reboot for the firmware to be active)/"scheduled"
+                      - "updated"/"installed"(which needs a reboot for the firmware to be active)/"scheduled"
+                      - "ns_boot_type/image_error/exec_fail"
 
         Raises:
             RuntimeError: auto-update failure cause

--- a/sonic_platform_base/component_base.py
+++ b/sonic_platform_base/component_base.py
@@ -104,19 +104,19 @@ class ComponentBase(object):
         """
         raise NotImplementedError
 
-    def auto_update_firmware(self, image_path, boot_action):
+    def auto_update_firmware(self, image_path, boot_type):
         """
         Updates firmware of the component
 
-        This API performs firmware update automatically based on boot_action: it assumes firmware installation
-        and/or creating a loading task during a boot action, if needed, in a single call.
+        This API performs firmware update automatically based on boot_type: it assumes firmware installation
+        and/or creating a loading task during the reboot, if needed, in a single call.
         In case platform component requires some extra steps (apart from calling Low Level Utility)
         to load the installed firmware (e.g, reboot, power cycle, etc.) - this will be done automatically during the reboot.
         The loading task will be created by API.
 
         Args:
             image_path: A string, path to firmware image
-            boot_action: A string, boot action following the upgrade
+            boot_type: A string, reboot type following the upgrade
                          - none/fast/warm/cold
 
         Returns:

--- a/sonic_platform_base/component_base.py
+++ b/sonic_platform_base/component_base.py
@@ -88,7 +88,7 @@ class ComponentBase(object):
         """
         raise NotImplementedError
 
-    def update_firmware(self, image_path, boot_action):
+    def update_firmware(self, image_path):
         """
         Updates firmware of the component
 
@@ -98,7 +98,26 @@ class ComponentBase(object):
 
         Args:
             image_path: A string, path to firmware image
+
+        Raises:
+            RuntimeError: update failed
+        """
+        raise NotImplementedError
+
+    def auto_update_firmware(self, image_path, boot_action, command):
+        """
+        Updates firmware of the component
+
+        This API performs firmware update automatically based on boot_action: it assumes firmware installation 
+        and creating a loading task in a single call.
+        In case platform component requires some extra steps (apart from calling Low Level Utility)
+        to load the installed firmware (e.g, reboot, power cycle, etc.) - this will be done automatically during the reboot.
+        The loading task will be created by API and it will be performed by the reboot script.
+
+        Args:
+            image_path: A string, path to firmware image
             boot_action: A string, boot action following the upgrade
+            command: A string, command to be performed
 
         Raises:
             RuntimeError: update failed

--- a/sonic_platform_base/component_base.py
+++ b/sonic_platform_base/component_base.py
@@ -108,7 +108,7 @@ class ComponentBase(object):
         """
         Updates firmware of the component
 
-        This API performs firmware update automatically based on boot_action: it assumes firmware installation 
+        This API performs firmware update automatically based on boot_action: it assumes firmware installation
         and/or creating a loading task during a boot action, if needed, in a single call.
         In case platform component requires some extra steps (apart from calling Low Level Utility)
         to load the installed firmware (e.g, reboot, power cycle, etc.) - this will be done automatically during the reboot.
@@ -117,6 +117,12 @@ class ComponentBase(object):
         Args:
             image_path: A string, path to firmware image
             boot_action: A string, boot action following the upgrade
+
+        Returns:
+            Output: A string, status and info
+                status: True or False, firmware auto-update status
+                info: The detail information of the firmware auto-update status.
+                    "updated"/"installed"(which needs a reboot for the firmware to be active)/"scheduled"
 
         Raises:
             RuntimeError: auto-update failure cause


### PR DESCRIPTION
To support the component firmware automatic update, add auto_update_firmware() to platform component api
This is to support fwutil auto_update command to update  the platform component firmware automatically.
Fwutil HLD to support auto_update interfaces/commands.
https://github.com/Azure/SONiC/pull/648