### PR TITLE
[sonic_sfp] The key for connector dict should be lowercase for class …

### DIFF
--- a/sonic_platform_base/sonic_sfp/sff8472.py
+++ b/sonic_platform_base/sonic_sfp/sff8472.py
@@ -281,7 +281,7 @@ class sff8472InterfaceId(sffbase):
              '09': 'MU',
              '0a': 'SG',
              '0b': 'Optical pigtail',
-             '0C': 'MPO Parallel Optic',
+             '0c': 'MPO Parallel Optic',
              '20': 'HSSDCII',
              '21': 'CopperPigtail',
              '22': 'RJ45'}


### PR DESCRIPTION
I change the definition for "MPO Parallel Optic" for connector dict