### PR TITLE
Remove sonic-config-engine dependency from setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,6 @@ setup(
         'sonic_thermal',
     ],
     install_requires=[
-        'sonic-config-engine',  # For portconfig. TODO: Remove this dependency
         'sonic-py-common'
     ],
     classifiers=[


### PR DESCRIPTION
Currently, we are building both Python 2 and Python 3 versions of sonic-platform-common. However, we are currently not creating a Python 3 version of sonic-config-engine, so the build breaks. As I intend to remove this dependency in the near future anyway, I am removing it.