### PR TITLE
Fix fp_port_index error to get correct index type

### DIFF
--- a/sonic_platform_base/sonic_sfp/sfputilbase.py
+++ b/sonic_platform_base/sonic_sfp/sfputilbase.py
@@ -405,7 +405,7 @@ class SfpUtilBase(object):
                     logical_to_bcm[intf_name] = "xe"+ bcm_port
 
                     if 'index' in ports[intf_name].keys():
-                        fp_port_index = ports[intf_name]['index']
+                        fp_port_index = int(ports[intf_name]['index'])
                         logical_to_physical[intf_name] = [fp_port_index]
 
                     if physical_to_logical.get(fp_port_index) is None:

--- a/sonic_platform_base/sonic_sfp/sfputilhelper.py
+++ b/sonic_platform_base/sonic_sfp/sfputilhelper.py
@@ -74,7 +74,7 @@ class SfpUtilHelper(object):
                     bcm_port = str(port_pos_in_file)
 
                     if 'index' in ports[intf_name].keys():
-                        fp_port_index = ports[intf_name]['index']
+                        fp_port_index = int(ports[intf_name]['index'])
                         logical_to_physical[intf_name] = [fp_port_index]
 
                     if physical_to_logical.get(fp_port_index) is None:


### PR DESCRIPTION
Signed-off-by: Sangita Maity <sangitamaity0211@gmail.com>

**Before this fix**


XCVRD was not working fine. 

```
Aug  6 19:06:12.026264 falco-test-dut01 INFO pmon#xcvrd: Start daemon init...
Aug  6 19:06:12.384054 falco-test-dut01 INFO pmon#xcvrd: chassis loaded <sonic_platform.chassis.Chassis object at 0x7f53ecbe9f50>
Aug  6 19:06:15.294866 falco-test-dut01 INFO pmon#xcvrd: xcvrd: No media file exists
Aug  6 19:06:15.296448 falco-test-dut01 INFO pmon#xcvrd: Wait for port config is done
Aug  6 19:06:15.302478 falco-test-dut01 INFO pmon#xcvrd: Post all port DOM/SFP info to DB
Aug  6 19:06:15.306300 falco-test-dut01 INFO pmon#supervisord: xcvrd Traceback (most recent call last):
Aug  6 19:06:15.306541 falco-test-dut01 INFO pmon#supervisord: xcvrd   File "/usr/bin/xcvrd", line 1083, in <module>
Aug  6 19:06:15.306859 falco-test-dut01 INFO pmon#supervisord: xcvrd     main()
Aug  6 19:06:15.307081 falco-test-dut01 INFO pmon#supervisord: xcvrd   File "/usr/bin/xcvrd", line 1080, in main
Aug  6 19:06:15.307231 falco-test-dut01 INFO pmon#supervisord: xcvrd     xcvrd.run()
Aug  6 19:06:15.307623 falco-test-dut01 INFO pmon#supervisord: xcvrd   File "/usr/bin/xcvrd", line 1044, in run
Aug  6 19:06:15.307813 falco-test-dut01 INFO pmon#supervisord: xcvrd     self.init()
Aug  6 19:06:15.307966 falco-test-dut01 INFO pmon#supervisord: xcvrd   File "/usr/bin/xcvrd", line 1028, in init
Aug  6 19:06:15.308159 falco-test-dut01 INFO pmon#supervisord: xcvrd     post_port_sfp_dom_info_to_db(is_warm_start, self.stop_event)
Aug  6 19:06:15.308351 falco-test-dut01 INFO pmon#supervisord: xcvrd   File "/usr/bin/xcvrd", line 387, in post_port_sfp_dom_info_to_db
Aug  6 19:06:15.308521 falco-test-dut01 INFO pmon#supervisord: xcvrd     post_port_sfp_info_to_db(logical_port_name, int_tbl, transceiver_dict, stop_event)
Aug  6 19:06:15.308672 falco-test-dut01 INFO pmon#supervisord: xcvrd   File "/usr/bin/xcvrd", line 223, in post_port_sfp_info_to_db
Aug  6 19:06:15.308843 falco-test-dut01 INFO pmon#supervisord: xcvrd     if not _wrapper_get_presence(physical_port):
Aug  6 19:06:15.308843 falco-test-dut01 INFO pmon#supervisord: xcvrd   File "/usr/bin/xcvrd", line 123, in _wrapper_get_presence
Aug  6 19:06:15.308886 falco-test-dut01 INFO pmon#supervisord: xcvrd     return platform_chassis.get_sfp(physical_port).get_presence()
Aug  6 19:06:15.308886 falco-test-dut01 INFO pmon#supervisord: xcvrd   File "/usr/local/lib/python2.7/dist-packages/sonic_platform/chassis.py", line 177, in get_sfp
Aug  6 19:06:15.308933 falco-test-dut01 INFO pmon#supervisord: xcvrd     sfp = self._sfp_list[index-1]
Aug  6 19:06:15.308985 falco-test-dut01 INFO pmon#supervisord: xcvrd TypeError: unsupported operand type(s) for -: 'str' and 'int'
```

**After the fix**


xcvrd is working fine.


```
root@falco-test-dut01:/# supervisorctl status | grep xcvrd
xcvrd                            RUNNING   pid 762, uptime 0:00:41
```

```
Aug  6 23:26:23.774262 falco-test-dut01 INFO pmon#xcvrd: xcvrd: No media file exists
Aug  6 23:26:23.777088 falco-test-dut01 INFO pmon#xcvrd: Wait for port config is done
Aug  6 23:26:23.792048 falco-test-dut01 INFO pmon#xcvrd: Post all port DOM/SFP info to DB
Aug  6 23:26:25.565349 falco-test-dut01 INFO pmon#xcvrd: Start DOM monitoring loop
Aug  6 23:26:25.571881 falco-test-dut01 INFO pmon#supervisord: xcvrd [1]
Aug  6 23:26:25.572407 falco-test-dut01 INFO pmon#supervisord: xcvrd [2]
Aug  6 23:26:25.573092 falco-test-dut01 INFO pmon#supervisord: xcvrd [3]
Aug  6 23:26:25.573754 falco-test-dut01 INFO pmon#supervisord: xcvrd [4]
Aug  6 23:26:25.573754 falco-test-dut01 INFO pmon#supervisord: xcvrd [5]
Aug  6 23:26:25.573754 falco-test-dut01 INFO pmon#supervisord: xcvrd [6]
Aug  6 23:26:25.573754 falco-test-dut01 INFO pmon#supervisord: xcvrd [7]
Aug  6 23:26:25.573839 falco-test-dut01 INFO pmon#supervisord: xcvrd [8]
Aug  6 23:26:25.573839 falco-test-dut01 INFO pmon#supervisord: xcvrd [9]
Aug  6 23:26:25.573870 falco-test-dut01 INFO pmon#supervisord: xcvrd [10]
Aug  6 23:26:25.573897 falco-test-dut01 INFO pmon#supervisord: xcvrd [11]
Aug  6 23:26:25.573897 falco-test-dut01 INFO pmon#supervisord: xcvrd [12]
Aug  6 23:26:25.573963 falco-test-dut01 INFO pmon#supervisord: xcvrd [13]
Aug  6 23:26:25.574042 falco-test-dut01 INFO pmon#supervisord: xcvrd [14]
Aug  6 23:26:25.574118 falco-test-dut01 INFO pmon#supervisord: xcvrd [15]
Aug  6 23:26:25.574430 falco-test-dut01 INFO pmon#supervisord: xcvrd [16]
Aug  6 23:26:25.574508 falco-test-dut01 INFO pmon#supervisord: xcvrd [17]
Aug  6 23:26:25.574585 falco-test-dut01 INFO pmon#supervisord: xcvrd [18]
Aug  6 23:26:25.574661 falco-test-dut01 INFO pmon#supervisord: xcvrd [19]
Aug  6 23:26:25.574737 falco-test-dut01 INFO pmon#supervisord: xcvrd [20]
Aug  6 23:26:25.574814 falco-test-dut01 INFO pmon#supervisord: xcvrd [21]
Aug  6 23:26:25.574890 falco-test-dut01 INFO pmon#supervisord: xcvrd [22]
Aug  6 23:26:25.574965 falco-test-dut01 INFO pmon#supervisord: xcvrd [23]
Aug  6 23:26:25.575110 falco-test-dut01 INFO pmon#supervisord: xcvrd [24]
Aug  6 23:26:25.575610 falco-test-dut01 INFO pmon#supervisord: xcvrd [25]
Aug  6 23:26:25.575698 falco-test-dut01 INFO pmon#supervisord: xcvrd [26]
Aug  6 23:26:25.575774 falco-test-dut01 INFO pmon#supervisord: xcvrd [27]
Aug  6 23:26:25.575850 falco-test-dut01 INFO pmon#supervisord: xcvrd [28]
Aug  6 23:26:25.575926 falco-test-dut01 INFO pmon#supervisord: xcvrd [29]
Aug  6 23:26:25.576002 falco-test-dut01 INFO pmon#supervisord: xcvrd [30]
Aug  6 23:26:25.576077 falco-test-dut01 INFO pmon#supervisord: xcvrd [31]
Aug  6 23:26:25.576153 falco-test-dut01 INFO pmon#supervisord: xcvrd [32]
Aug  6 23:26:25.576250 falco-test-dut01 INFO pmon#xcvrd: Start daemon main loop
Aug  6 23:26:25.578331 falco-test-dut01 INFO pmon#xcvrd: Start SFP monitoring loop
```