### PR TITLE
[sffbase.py] return None when parsed element's offset is out of range of eeprom_data

### DIFF
--- a/sonic_platform_base/sonic_sfp/sffbase.py
+++ b/sonic_platform_base/sonic_sfp/sffbase.py
@@ -94,6 +94,9 @@ class sffbase(object):
         type   = eeprom_ele.get('type')
         decode = eeprom_ele.get('decode');
 
+        if offset + size > len(eeprom_data):
+            return None
+
         if type == 'enum':
             # Get the matched value
             value = decode.get(str(eeprom_data[offset]), 'Unknown')


### PR DESCRIPTION
Done to avoid crash on platforms that does not support offsets introduced by https://github.com/Azure/sonic-platform-common/pull/108

Signed-off-by: Volodymyr Boyko <volodymyrx.boiko@intel.com>