### PR TITLE
[sfputilbase|sfputilhelper] fix value unpack error due to port_alias_map in portconfig.py file

### DIFF
--- a/sonic_platform_base/sonic_sfp/sfputilbase.py
+++ b/sonic_platform_base/sonic_sfp/sfputilbase.py
@@ -392,7 +392,7 @@ class SfpUtilBase(object):
 
         (platform, hwsku) = device_info.get_platform_and_hwsku()
         if(parse_fmt_platform_json):
-            ports, _ = get_port_config(hwsku, platform)
+            ports, _, _ = get_port_config(hwsku, platform)
             if not ports:
                 print('Failed to get port config', file=sys.stderr)
                 sys.exit(1)

--- a/sonic_platform_base/sonic_sfp/sfputilhelper.py
+++ b/sonic_platform_base/sonic_sfp/sfputilhelper.py
@@ -63,7 +63,7 @@ class SfpUtilHelper(object):
 
         (platform, hwsku) = device_info.get_platform_and_hwsku()
         if(parse_fmt_platform_json):
-            ports, _ = get_port_config(hwsku, platform)
+            ports, _, _ = get_port_config(hwsku, platform)
             if not ports:
                 print('Failed to get port config', file=sys.stderr)
                 sys.exit(1)


### PR DESCRIPTION
Signed-off-by: Sangita Maity <sangitamaity0211@gmail.com>
**Before this fix**

sfputilbbase and sfputilhelper were not able to unpack the value correctly as `get_port_config` function was returning three variables including the new port_alias_map dictionary. 
```
admin@lnos-x1-a-asw02:~$ show interfaces transceiver lpmode
Error reading port info (too many values to unpack)
```

**After the fix**
```
admin@lnos-x1-a-asw02:~$ show interfaces transceiver lpmode --verbose
Command: sudo sfputil show lpmode
Port         Low-power Mode
-----------  ----------------
Ethernet0    Off
Ethernet1    Off
Ethernet2    Off
Ethernet3    Off
Ethernet4    Off
Ethernet5    Off
Ethernet6    Off
Ethernet7    Off
Ethernet8    Off
Ethernet9    Off
```


- Which release branch to backport (provide reason below if selected)
- [ ] 202006