### PR TITLE
[201911] [ multi-asic] Remove the use of constant PORT_CONFIG_INI in sonic_sfp

### DIFF
--- a/sonic_platform_base/sonic_sfp/sfputilbase.py
+++ b/sonic_platform_base/sonic_sfp/sfputilbase.py
@@ -467,13 +467,9 @@ class SfpUtilBase(object):
         # In multi asic scenario, get all the port_config files for different asics
          for inst in range(num_asic_inst):
              port_map_dir = os.path.join(platform_dir, str(inst))
-             port_map_file = os.path.join(port_map_dir, PORT_CONFIG_INI)
+             port_map_file = os.path.join(port_map_dir, "port_config.ini")
              if os.path.exists(port_map_file):
                  self.read_porttab_mappings(port_map_file, inst)
-             else:
-                 port_json_file = os.path.join(port_map_dir, PLATFORM_JSON)
-                 if os.path.exists(port_json_file):
-                     self.read_porttab_mappings(port_json_file, inst)
 
     def read_phytab_mappings(self, phytabfile):
         logical = []

--- a/sonic_platform_base/sonic_sfp/sfputilhelper.py
+++ b/sonic_platform_base/sonic_sfp/sfputilhelper.py
@@ -135,13 +135,9 @@ class SfpUtilHelper(object):
         # In multi asic scenario, get all the port_config files for different asics
          for inst in range(num_asic_inst):
              port_map_dir = os.path.join(platform_dir, str(inst))
-             port_map_file = os.path.join(port_map_dir, PORT_CONFIG_INI)
+             port_map_file = os.path.join(port_map_dir, "port_config.ini")
              if os.path.exists(port_map_file):
                  self.read_porttab_mappings(port_map_file, inst)
-             else:
-                 port_json_file = os.path.join(port_map_dir, PLATFORM_JSON)
-                 if os.path.exists(port_json_file):
-                     self.read_porttab_mappings(port_json_file, inst)
 
     def get_physical_to_logical(self, port_num):
         """Returns list of logical ports for the given physical port"""


### PR DESCRIPTION
Remove the use of constant PORT_CONFIG_INI in 201911 in sonic_sfp.  

This is a follow up commit to the earlier 201911 commit https://github.com/Azure/sonic-platform-common/pull/117 ( double commit of https://github.com/Azure/sonic-platform-common/pull/100 in master ) 