### PR TITLE
Add support to get eeprom for some specific transceiver

### DIFF
--- a/sonic_platform_base/sonic_sfp/sffbase.py
+++ b/sonic_platform_base/sonic_sfp/sffbase.py
@@ -36,7 +36,7 @@ class sffbase(object):
             ret_str = ''
             for n in range(start, end):
                 ret_str += arr[n]
-            return str.strip(binascii.unhexlify(ret_str))
+            return str.rstrip(binascii.unhexlify(ret_str),'\xff')
         except Exception as err:
             return str(err)
 


### PR DESCRIPTION
**- What I did**
Ignore \xff for hex_to_string

**- How to verify it**
show interfaces transceiver eeprom Ethernet16

**- Previous command output**
Traceback (most recent call last):
  File "/usr/bin/sfpshow", line 219, in <module>
    cli()
  File "/usr/lib/python2.7/dist-packages/click/core.py", line 722, in __call__
    return self.main(*args, **kwargs)
  File "/usr/lib/python2.7/dist-packages/click/core.py", line 697, in main
    rv = self.invoke(ctx)
  File "/usr/lib/python2.7/dist-packages/click/core.py", line 1066, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/usr/lib/python2.7/dist-packages/click/core.py", line 895, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/usr/lib/python2.7/dist-packages/click/core.py", line 535, in invoke
    return callback(*args, **kwargs)
  File "/usr/bin/sfpshow", line 209, in eeprom
    sfp.display_eeprom(port, dump_dom)
  File "/usr/bin/sfpshow", line 154, in display_eeprom
    out_put = self.convert_interface_sfp_info_to_cli_output_string(self.sdb, interfacename, dump_dom)
  File "/usr/bin/sfpshow", line 138, in convert_interface_sfp_info_to_cli_output_string
    out_put = out_put + sfp_info_output
UnicodeDecodeError: 'ascii' codec can't decode byte 0xff in position 540: ordinal not in range(128)

127.0.0.1:6379[6]> hgetall "TRANSCEIVER_INFO|Ethernet12"
1) "type"
2) "QSFP28 or later"
3) "hardwarerev"
4) "01"
5) "serialnum"
6) **"J1192500001\xff\xff\xff\xff\xff"**
7) "manufacturename"
8) "Edgecore "
9) "modelname"
10) "ET7402-100DAC-1M"
11) "vendor_oui"
12) "70-72-cf"
13) "vendor_date"
14) "2017-06-28 "
15) "Connector"
16) "No separable connector"
17) "encoding"
18) "Unspecified"
19) "ext_identifier"
20) "Power Class 1(1.5W max)"
21) "ext_rateselect_compliance"
22) "QSFP+ Rate Select Version 1"
23) "cable_type"
24) "Length Cable Assembly(m)"
25) "cable_length"
26) "1"
27) "specification_compliance"
28) "{}"
29) "nominal_bit_rate"
30) "255"
Signed-off-by: chiourung_huang <chiourung_huang@edge-core.com>