### PR TITLE
[SONIC_SFP] adding abstract methods for reading and writing the eeprom address space within platform api

### DIFF
--- a/sonic_platform_base/sfp_base.py
+++ b/sonic_platform_base/sfp_base.py
@@ -307,8 +307,7 @@ class SfpBase(device_base.DeviceBase):
 
     def read_eeprom(self, offset, num_bytes):
         """
-        read eeprom specfic bytes for a given port_num and device id
-        beginning from a random offset with size as num_bytes
+        read eeprom specfic bytes beginning from a random offset with size as num_bytes
 
         Args:
              offset :
@@ -323,8 +322,8 @@ class SfpBase(device_base.DeviceBase):
 
     def write_eeprom(self, offset, num_bytes, write_buffer):
         """
-        write eeprom specfic bytes for a given port_num and device id
-        beginning from a random offset with size as num_bytes and write_buffer as the required bytes
+        write eeprom specfic bytes beginning from a random offset with size as num_bytes 
+        and write_buffer as the required bytes
 
         Args:
              offset :

--- a/sonic_platform_base/sfp_base.py
+++ b/sonic_platform_base/sfp_base.py
@@ -308,7 +308,7 @@ class SfpBase(device_base.DeviceBase):
     def read_eeprom(self, offset, num_bytes):
         """
         read eeprom specfic bytes for a given port_num and device id
-        begining from a random offset with size as num_bytes
+        beginning from a random offset with size as num_bytes
 
         Args:
              offset :
@@ -317,22 +317,22 @@ class SfpBase(device_base.DeviceBase):
                      Integer, the number of bytes to be read
 
         Returns:
-            a bytearray , raw sequence of bytes which are read from the offset of size num_bytes
+            bytes, raw sequence of bytes which are read from the offset of size num_bytes
         """
         raise NotImplementedError
 
     def write_eeprom(self, offset, num_bytes, write_buffer):
         """
         write eeprom specfic bytes for a given port_num and device id
-        begining from a random offset with size as num_bytes and write_buffer as the required bytes
+        beginning from a random offset with size as num_bytes and write_buffer as the required bytes
 
         Args:
              offset :
                      Integer, the offset from which the read transaction will start
              num_bytes:
-                     Integer, the number of bytes to be read
+                     Integer, the number of bytes to be written
              write_buffer:
-                     bytearary, raw bytes buffer which is to be written beginning at the offset
+                     bytes, raw bytes buffer which is to be written beginning at the offset
 
         Returns:
             a Boolean, true if the write succeeded and false if it did not succeed.

--- a/sonic_platform_base/sfp_base.py
+++ b/sonic_platform_base/sfp_base.py
@@ -316,7 +316,8 @@ class SfpBase(device_base.DeviceBase):
                      Integer, the number of bytes to be read
 
         Returns:
-            bytearray, raw sequence of bytes which are read from the offset of size num_bytes
+            bytearray, if raw sequence of bytes are read correctly from the offset of size num_bytes
+            None , if the read_eeprom fails
         """
         raise NotImplementedError
 

--- a/sonic_platform_base/sfp_base.py
+++ b/sonic_platform_base/sfp_base.py
@@ -317,7 +317,7 @@ class SfpBase(device_base.DeviceBase):
 
         Returns:
             bytearray, if raw sequence of bytes are read correctly from the offset of size num_bytes
-            None , if the read_eeprom fails
+            None, if the read_eeprom fails
         """
         raise NotImplementedError
 

--- a/sonic_platform_base/sfp_base.py
+++ b/sonic_platform_base/sfp_base.py
@@ -305,45 +305,37 @@ class SfpBase(device_base.DeviceBase):
         """
         raise NotImplementedError
 
-    def read_eeprom_devid(self, port_num, devid, offset, num_bytes):
+    def read_eeprom(self, offset, num_bytes):
         """
         read eeprom specfic bytes for a given port_num and device id
         begining from a random offset with size as num_bytes
 
         Args:
-             port_num :
-                     Integer, index of physical port from where to read the bytes
-             devid :
-                     Integer, device id of the i2c bus required for reading for eeprom addr space
              offset :
                      Integer, the offset from which the read transaction will start
              num_bytes:
                      Integer, the number of bytes to be read
 
         Returns:
-            a list , raw sequence of bytes which are read from the offset of size num_bytes
+            a bytearray , raw sequence of bytes which are read from the offset of size num_bytes
         """
         raise NotImplementedError
 
-    def write_eeprom_devid(self, port_num, devid, offset, num_bytes, write_buffer):
+    def write_eeprom(self, offset, num_bytes, write_buffer):
         """
         write eeprom specfic bytes for a given port_num and device id
         begining from a random offset with size as num_bytes and write_buffer as the required bytes
 
         Args:
-             port_num :
-                     Integer, index of physical port from where to read the bytes
-             devid :
-                     Integer, device id of the i2c bus required for reading for eeprom addr space
              offset :
                      Integer, the offset from which the read transaction will start
              num_bytes:
                      Integer, the number of bytes to be read
              write_buffer:
-                     list, raw bytes buffer which is to be written beginning at the offset
+                     bytearary, raw bytes buffer which is to be written beginning at the offset
 
         Returns:
-            a Boolean , true if the write succeeded and false if it did not succeed.
+            a Boolean, true if the write succeeded and false if it did not succeed.
         """
         raise NotImplementedError
 

--- a/sonic_platform_base/sfp_base.py
+++ b/sonic_platform_base/sfp_base.py
@@ -304,3 +304,47 @@ class SfpBase(device_base.DeviceBase):
             False if not
         """
         raise NotImplementedError
+
+    def read_eeprom_devid(self, port_num, devid, offset, num_bytes):
+        """
+        read eeprom specfic bytes for a given port_num and device id
+        begining from a random offset with size as num_bytes
+
+        Args:
+             port_num :
+                     Integer, index of physical port from where to read the bytes
+             devid :
+                     Integer, device id of the i2c bus required for reading for eeprom addr space
+             offset :
+                     Integer, the offset from which the read transaction will start
+             num_bytes:
+                     Integer, the number of bytes to be read
+
+        Returns:
+            a list , raw sequence of bytes which are read from the offset of size num_bytes
+        """
+        raise NotImplementedError
+
+    def write_eeprom_devid(self, port_num, devid, offset, num_bytes, write_buffer):
+        """
+        write eeprom specfic bytes for a given port_num and device id
+        begining from a random offset with size as num_bytes and write_buffer as the required bytes
+
+        Args:
+             port_num :
+                     Integer, index of physical port from where to read the bytes
+             devid :
+                     Integer, device id of the i2c bus required for reading for eeprom addr space
+             offset :
+                     Integer, the offset from which the read transaction will start
+             num_bytes:
+                     Integer, the number of bytes to be read
+             write_buffer:
+                     list, raw bytes buffer which is to be written beginning at the offset
+
+        Returns:
+            a Boolean , true if the write succeeded and false if it did not succeed.
+        """
+        raise NotImplementedError
+
+

--- a/sonic_platform_base/sfp_base.py
+++ b/sonic_platform_base/sfp_base.py
@@ -316,7 +316,7 @@ class SfpBase(device_base.DeviceBase):
                      Integer, the number of bytes to be read
 
         Returns:
-            bytes, raw sequence of bytes which are read from the offset of size num_bytes
+            bytearray, raw sequence of bytes which are read from the offset of size num_bytes
         """
         raise NotImplementedError
 
@@ -331,7 +331,7 @@ class SfpBase(device_base.DeviceBase):
              num_bytes:
                      Integer, the number of bytes to be written
              write_buffer:
-                     bytes, raw bytes buffer which is to be written beginning at the offset
+                     bytearray, raw bytes buffer which is to be written beginning at the offset
 
         Returns:
             a Boolean, true if the write succeeded and false if it did not succeed.

--- a/sonic_platform_base/sonic_sfp/sffbase.py
+++ b/sonic_platform_base/sonic_sfp/sffbase.py
@@ -6,7 +6,6 @@
 from __future__ import print_function
 
 try:
-    import abc
     import fcntl
     import struct
     import sys
@@ -22,8 +21,6 @@ except ImportError as e:
 class sffbase(object):
     """Class to parse and interpret sff8436 and sff8472 spec for
     diagnostically monitoring interfaces of optical transceivers"""
-
-    __metaclass__ = abc.ABCMeta
 
     _indent = '\t'
 
@@ -250,27 +247,3 @@ class sffbase(object):
                     self.dec_indent()
             else:
                 print(self._indent, elem, ': ', elem_val)
-
-    @abc.abstractmethod
-    def read_eeprom_devid(self, port_num, devid, offset, num_bytes):
-        """
-        :param port_num: Integer, index of physical port
-        :param devid: Integer, device id of the i2c bus required for reading for eeprom addr space
-        :param offset: Integer, the offset from which the read transaction will start
-        :param num_bytes: Integer, the number of bytes to be read
-        :returns: list , raw sequence of bytes which are read from the offset of size num_bytes
-        """
-        return
-
-    @abc.abstractmethod
-    def write_eeprom_devid(self, port_num, devid, offset, num_bytes, write_buffer):
-        """
-        :param port_num: Integer, index of physical port
-        :param devid: Integer, device id of the i2c bus required for reading for eeprom addr space
-        :param offset: Integer, the offset from which the read transaction will start
-        :param num_bytes: Integer, the number of bytes to be read
-        :param write_buffer: list, raw bytes buffer needed to be written beginning at the offset
-        :returns: list , raw sequence of bytes which are read from the offset of size num_bytes
-        """
-        return
-

--- a/sonic_platform_base/sonic_sfp/sffbase.py
+++ b/sonic_platform_base/sonic_sfp/sffbase.py
@@ -6,6 +6,7 @@
 from __future__ import print_function
 
 try:
+    import abc
     import fcntl
     import struct
     import sys
@@ -21,6 +22,8 @@ except ImportError as e:
 class sffbase(object):
     """Class to parse and interpret sff8436 and sff8472 spec for
     diagnostically monitoring interfaces of optical transceivers"""
+
+    __metaclass__ = abc.ABCMeta
 
     _indent = '\t'
 
@@ -247,3 +250,27 @@ class sffbase(object):
                     self.dec_indent()
             else:
                 print(self._indent, elem, ': ', elem_val)
+
+    @abc.abstractmethod
+    def read_eeprom_devid(self, port_num, devid, offset, num_bytes):
+        """
+        :param port_num: Integer, index of physical port
+        :param devid: Integer, device id of the i2c bus required for reading for eeprom addr space
+        :param offset: Integer, the offset from which the read transaction will start
+        :param num_bytes: Integer, the number of bytes to be read
+        :returns: list , raw sequence of bytes which are read from the offset of size num_bytes
+        """
+        return
+
+    @abc.abstractmethod
+    def write_eeprom_devid(self, port_num, devid, offset, num_bytes, write_buffer):
+        """
+        :param port_num: Integer, index of physical port
+        :param devid: Integer, device id of the i2c bus required for reading for eeprom addr space
+        :param offset: Integer, the offset from which the read transaction will start
+        :param num_bytes: Integer, the number of bytes to be read
+        :param write_buffer: list, raw bytes buffer needed to be written beginning at the offset
+        :returns: list , raw sequence of bytes which are read from the offset of size num_bytes
+        """
+        return
+


### PR DESCRIPTION
Summary:
This PR defines the base class methods for reading and writing eeprom address space, which is going to be utilized by 
xcvrd and cli for as a part of mux driver implementation for the Credo Y cable. With this change vendors will have to implement these api's as a part of SFP's since they inherit sffbase class which in turn will provide the upper layers to be able to read/write the sysfs eeprom address space

### Type of change

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
Added changes in the sonic_sfp directory of sonic-platform-common
#### What is the motivation for this PR?

To configure the Credo Y cable through the Platform API's which is the fundamental for dual TOR support for SONIC

#### How did you do it?
Added the API's with the abstract definitions 
for the basic configurations/capabilities of Credo Y cable within sfputilbase.py

#### How did you verify/test it?
Nothing to verify

#### Any platform specific information?

Platform must have optoe driver support for  instantiation of sysfs/eeprom 


Signed-off-by: vaibhav-dahiya <vdahiya@microsoft.com>
