### PR TITLE
[ChassisBase][ModuleBase] Remove redundant 'get_serial_number()' method

### DIFF
--- a/sonic_platform_base/chassis_base.py
+++ b/sonic_platform_base/chassis_base.py
@@ -82,15 +82,6 @@ class ChassisBase(device_base.DeviceBase):
         """
         raise NotImplementedError
 
-    def get_serial_number(self):
-        """
-        Retrieves the hardware serial number for the chassis
-
-        Returns:
-            A string containing the hardware serial number for this chassis.
-        """
-        raise NotImplementedError
-
     def get_system_eeprom_info(self):
         """
         Retrieves the full content of system EEPROM information for the chassis

--- a/sonic_platform_base/module_base.py
+++ b/sonic_platform_base/module_base.py
@@ -54,15 +54,6 @@ class ModuleBase(device_base.DeviceBase):
         """
         raise NotImplementedError
 
-    def get_serial_number(self):
-        """
-        Retrieves the hardware serial number for the module
-
-        Returns:
-            A string containing the hardware serial number for this module.
-        """
-        raise NotImplementedError
-
     def get_system_eeprom_info(self):
         """
         Retrieves the full content of system EEPROM information for the module 


### PR DESCRIPTION
ChassisBase and ModuleBase inherit from the DeviceBase class, which already provides a `get_serial()` method. Thus, these methods were redundant.