### PR TITLE
[sonic_platform_base][fan_drawer_base] adding get_fan definition to the base api definitions of fan_drawer base class

### DIFF
--- a/sonic_platform_base/fan_drawer_base.py
+++ b/sonic_platform_base/fan_drawer_base.py
@@ -37,6 +37,29 @@ class FanDrawerBase(device_base.DeviceBase):
         """
         return self._fan_list
 
+     def get_fan(self, index):
+        """
+        Retrieves fan module represented by (0-based) index <index>
+
+        Args:
+            index: An integer, the index (0-based) of the fan module to
+            retrieve
+
+        Returns:
+            An object dervied from FanBase representing the specified fan
+            module
+        """
+        fan = None
+
+        try:
+            fan = self._fan_list[index]
+        except IndexError:
+            sys.stderr.write("Fan index {} out of range (0-{})\n".format(
+                             index, len(self._fan_list)-1))
+
+        return fan
+
+
     def set_status_led(self, color):
         """
         Sets the state of the fan drawer status LED


### PR DESCRIPTION
Summary:
This PR adds the definition of get_fan api for fan_drawer base class, since it was missing for base_class definitions. 
It takes an index parameter and returns the appropriate fan instance of fan_base class. 

### Type of change

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
Added definition of the api in the sonic_platform_base directory of sonic-platform-common. 

#### What is the motivation for this PR?

To improve platform_api of fan_drawer class

#### How did you do it?
Added definition of the api in the sonic_platform_base directory of sonic-platform-common. 

#### How did you verify/test it?
Nothing to verify, since this is a base class definition


Signed-off-by: vaibhav-dahiya <vdahiya@microsoft.com>

