### PR TITLE
[sonic_platform_base] fix an indentation in fan_drawer_base.py

### DIFF
--- a/sonic_platform_base/fan_drawer_base.py
+++ b/sonic_platform_base/fan_drawer_base.py
@@ -37,7 +37,7 @@ class FanDrawerBase(device_base.DeviceBase):
         """
         return self._fan_list
 
-     def get_fan(self, index):
+    def get_fan(self, index):
         """
         Retrieves fan module represented by (0-based) index <index>
 


### PR DESCRIPTION
Fix the new definition of get_fan in fan_drawer_base.py

Signed-off-by: vaibhav-dahiya <vdahiya@microsoft.com>