### PR TITLE
[sonic-platform-common] Add new platform API for SONiC Physical MIB Extension feature

### DIFF
--- a/sonic_platform_base/device_base.py
+++ b/sonic_platform_base/device_base.py
@@ -58,18 +58,18 @@ class DeviceBase(object):
         raise NotImplementedError
 
     def get_position_in_parent(self):
-		"""
-		Retrieves 1-based relative physical position in parent device. If the agent cannot determine the parent-relative position
+        """
+        Retrieves 1-based relative physical position in parent device. If the agent cannot determine the parent-relative position
         for some reason, or if the associated value of entPhysicalContainedIn is '0', then the value '-1' is returned
-		Returns:
-		    integer: The 1-based relative physical position in parent device or -1 if cannot determine the position
-		"""
-		raise NotImplementedError
+        Returns:
+            integer: The 1-based relative physical position in parent device or -1 if cannot determine the position
+        """
+        raise NotImplementedError
 
     def is_replaceable(self):
-		"""
-		Indicate whether this device is replaceable.
-		Returns:
-		    bool: True if it is replaceable.
-		"""
-		raise NotImplementedError
+        """
+        Indicate whether this device is replaceable.
+        Returns:
+            bool: True if it is replaceable.
+        """
+        raise NotImplementedError

--- a/sonic_platform_base/device_base.py
+++ b/sonic_platform_base/device_base.py
@@ -59,9 +59,10 @@ class DeviceBase(object):
 
     def get_position_in_parent(self):
 		"""
-		Retrieves 1-based relative physical position in parent device
+		Retrieves 1-based relative physical position in parent device. If the agent cannot determine the parent-relative position
+        for some reason, or if the associated value of entPhysicalContainedIn is '0', then the value '-1' is returned
 		Returns:
-		    integer: The 1-based relative physical position in parent device
+		    integer: The 1-based relative physical position in parent device or -1 if cannot determine the position
 		"""
 		raise NotImplementedError
 

--- a/sonic_platform_base/device_base.py
+++ b/sonic_platform_base/device_base.py
@@ -56,3 +56,19 @@ class DeviceBase(object):
             A boolean value, True if device is operating properly, False if not
         """
         raise NotImplementedError
+
+    def get_position_in_parent(self):
+		"""
+		Retrieves 1-based relative physical position in parent device
+		Returns:
+		    integer: The 1-based relative physical position in parent device
+		"""
+		raise NotImplementedError
+
+    def is_replaceable(self):
+		"""
+		Indicate whether this device is replaceable.
+		Returns:
+		    bool: True if it is replaceable.
+		"""
+		raise NotImplementedError

--- a/sonic_platform_base/psu_base.py
+++ b/sonic_platform_base/psu_base.py
@@ -28,6 +28,10 @@ class PsuBase(device_base.DeviceBase):
     def __init__(self):
         self._fan_list = []
 
+        # List of ThermalBase-derived objects representing all thermals
+        # available on the PSU
+        self._thermal_list = []
+
     def get_num_fans(self):
         """
         Retrieves the number of fan modules available on this PSU
@@ -68,6 +72,46 @@ class PsuBase(device_base.DeviceBase):
                              index, len(self._fan_list)-1))
 
         return fan
+
+    def get_num_thermals(self):
+        """
+        Retrieves the number of thermals available on this PSU
+
+        Returns:
+            An integer, the number of thermals available on this PSU
+        """
+        return len(self._thermal_list)
+
+    def get_all_thermals(self):
+        """
+        Retrieves all thermals available on this PSU
+
+        Returns:
+            A list of objects derived from ThermalBase representing all thermals
+            available on this PSU
+        """
+        return self._thermal_list
+
+    def get_thermal(self, index):
+        """
+        Retrieves thermal unit represented by (0-based) index <index>
+
+        Args:
+            index: An integer, the index (0-based) of the thermal to
+            retrieve
+
+        Returns:
+            An object dervied from ThermalBase representing the specified thermal
+        """
+        thermal = None
+
+        try:
+            thermal = self._thermal_list[index]
+        except IndexError:
+            sys.stderr.write("THERMAL index {} out of range (0-{})\n".format(
+                             index, len(self._thermal_list)-1))
+
+        return thermal
 
     def get_voltage(self):
         """

--- a/sonic_platform_base/psu_base.py
+++ b/sonic_platform_base/psu_base.py
@@ -25,6 +25,13 @@ class PsuBase(device_base.DeviceBase):
     # available on the PSU
     _fan_list = None
 
+    # List of ThermalBase-derived objects representing all thermals
+    # available on the PSU. Put a class level _thermal_list here to 
+    # avoid an exception when call get_num_thermals, get_all_thermals
+    # and get_thermal if vendor does not call PsuBase.__init__ in concrete
+    # PSU class
+    _thermal_list = []
+
     def __init__(self):
         self._fan_list = []
 

--- a/sonic_platform_base/sfp_base.py
+++ b/sonic_platform_base/sfp_base.py
@@ -16,6 +16,51 @@ class SfpBase(device_base.DeviceBase):
     # Device type definition. Note, this is a constant.
     DEVICE_TYPE = "sfp"
 
+    def __init__(self):
+        # List of ThermalBase-derived objects representing all thermals
+        # available on the SFP
+        self._thermal_list = []
+
+    def get_num_thermals(self):
+        """
+        Retrieves the number of thermals available on this SFP
+
+        Returns:
+            An integer, the number of thermals available on this SFP
+        """
+        return len(self._thermal_list)
+
+    def get_all_thermals(self):
+        """
+        Retrieves all thermals available on this SFP
+
+        Returns:
+            A list of objects derived from ThermalBase representing all thermals
+            available on this SFP
+        """
+        return self._thermal_list
+
+    def get_thermal(self, index):
+        """
+        Retrieves thermal unit represented by (0-based) index <index>
+
+        Args:
+            index: An integer, the index (0-based) of the thermal to
+            retrieve
+
+        Returns:
+            An object derived from ThermalBase representing the specified thermal
+        """
+        thermal = None
+
+        try:
+            thermal = self._thermal_list[index]
+        except IndexError:
+            sys.stderr.write("THERMAL index {} out of range (0-{})\n".format(
+                             index, len(self._thermal_list)-1))
+
+        return thermal
+
     def get_transceiver_info(self):
         """
         Retrieves transceiver info of this SFP

--- a/sonic_platform_base/sfp_base.py
+++ b/sonic_platform_base/sfp_base.py
@@ -16,6 +16,13 @@ class SfpBase(device_base.DeviceBase):
     # Device type definition. Note, this is a constant.
     DEVICE_TYPE = "sfp"
 
+    # List of ThermalBase-derived objects representing all thermals
+    # available on the SFP. Put a class level _thermal_list here to 
+    # avoid an exception when call get_num_thermals, get_all_thermals
+    # and get_thermal if vendor does not call SfpBase.__init__ in concrete
+    # SFP class
+    _thermal_list = []
+
     def __init__(self):
         # List of ThermalBase-derived objects representing all thermals
         # available on the SFP


### PR DESCRIPTION
Why I did this?

In order to implement physical entity mib object entPhysicalParentRelPos, entPhysicalContainedIn and entPhysicalIsFRU, new platform API is required to collect information from each vendor.

What I did?
1. Add DeviceBase.is_replaceable and DeviceBase.get_position_in_parent
2. Add PsuBase.get_num_thermals, PsuBase.get_all_thermals, PsuBase.get_thermal
3. Add SfpBase.get_num_thermals, SfpBase.get_all_thermals, SfpBase.get_thermal