### PR TITLE
Common power consumption and supply APIs for modular chassis

### DIFF
--- a/sonic_platform_base/chassis_base.py
+++ b/sonic_platform_base/chassis_base.py
@@ -26,12 +26,6 @@ class ChassisBase(device_base.DeviceBase):
     REBOOT_CAUSE_HARDWARE_OTHER = "Hardware - Other"
     REBOOT_CAUSE_NON_HARDWARE = "Non-Hardware"
 
-    # Possible fan status LED colors
-    STATUS_LED_COLOR_GREEN = "green"
-    STATUS_LED_COLOR_AMBER = "amber"
-    STATUS_LED_COLOR_RED = "red"
-    STATUS_LED_COLOR_OFF = "off"
-
     # List of ComponentBase-derived objects representing all components
     # available on the chassis
     _component_list = None
@@ -150,6 +144,17 @@ class ChassisBase(device_base.DeviceBase):
         """
         return NotImplementedError
 
+    def is_modular_chassis(self):
+        """
+        Retrieves whether the sonic instance is part of modular chassis
+
+        Returns:
+            A bool value, should return False by default or for fixed-platforms.
+            Should return True for supervisor-cards, line-cards etc running as part
+            of modular-chassis.
+        """
+        return False
+
     ##############################################
     # Component methods
     ##############################################
@@ -192,45 +197,6 @@ class ChassisBase(device_base.DeviceBase):
                              index, len(self._component_list)-1))
 
         return component
-
-    def get_all_power_consumers(self):
-        """
-        Retrieves a list of all power consumers in a modular chassis
-
-        Returns:
-            A list, where each entry is a unique power consumer. For example,
-            'FAN', 'CARD' etc
-        """
-        return None
-
-    def get_total_consumer_power(self, consumer):
-        """
-        Retrives the maximum total power drawn by the consumer component
-
-        Returns:
-            A float, with value of the maximum consumable power of the
-            component.
-        """
-        return 0.0
-
-    def get_status_master_led(self, device_type):
-        """
-        Gets the state of the Master status LED for a given device-type
-
-        Returns:
-            A string, one of the predefined STATUS_LED_COLOR_* strings.
-        """
-        return STATUS_LED_COLOR_OFF
-
-    def set_status_master_led(self, device_type, color):
-        """
-        Gets the state of the Master status LED for a given device-type
-
-        Returns:
-            bool: True if status LED state is set successfully, False if
-                  not
-        """
-        return False
 
     ##############################################
     # Module methods

--- a/sonic_platform_base/chassis_base.py
+++ b/sonic_platform_base/chassis_base.py
@@ -26,6 +26,12 @@ class ChassisBase(device_base.DeviceBase):
     REBOOT_CAUSE_HARDWARE_OTHER = "Hardware - Other"
     REBOOT_CAUSE_NON_HARDWARE = "Non-Hardware"
 
+    # Possible fan status LED colors
+    STATUS_LED_COLOR_GREEN = "green"
+    STATUS_LED_COLOR_AMBER = "amber"
+    STATUS_LED_COLOR_RED = "red"
+    STATUS_LED_COLOR_OFF = "off"
+
     # List of ComponentBase-derived objects representing all components
     # available on the chassis
     _component_list = None
@@ -186,6 +192,45 @@ class ChassisBase(device_base.DeviceBase):
                              index, len(self._component_list)-1))
 
         return component
+
+    def get_all_power_consumers(self):
+        """
+        Retrieves a list of all power consumers in a modular chassis
+
+        Returns:
+            A list, where each entry is a unique power consumer. For example,
+            'FAN', 'CARD' etc
+        """
+        return None
+
+    def get_total_consumer_power(self, consumer):
+        """
+        Retrives the maximum total power drawn by the consumer component
+
+        Returns:
+            A float, with value of the maximum consumable power of the
+            component.
+        """
+        return 0.0
+
+    def get_status_master_led(self, device_type):
+        """
+        Gets the state of the Master status LED for a given device-type
+
+        Returns:
+            A string, one of the predefined STATUS_LED_COLOR_* strings.
+        """
+        return STATUS_LED_COLOR_OFF
+
+    def set_status_master_led(self, device_type, color):
+        """
+        Gets the state of the Master status LED for a given device-type
+
+        Returns:
+            bool: True if status LED state is set successfully, False if
+                  not
+        """
+        return False
 
     ##############################################
     # Module methods

--- a/sonic_platform_base/device_base.py
+++ b/sonic_platform_base/device_base.py
@@ -10,6 +10,10 @@ class DeviceBase(object):
     Abstract base class for interfacing with a generic type of platform
     peripheral device
     """
+    #Device-types
+    DEVICE_TYPE_PSU     = "PSU"
+    DEVICE_TYPE_FAN     = "FAN"
+    DEVICE_TYPE_FANDRAWER = "FAN-DRAWER"
 
     def get_name(self):
         """

--- a/sonic_platform_base/device_base.py
+++ b/sonic_platform_base/device_base.py
@@ -10,10 +10,17 @@ class DeviceBase(object):
     Abstract base class for interfacing with a generic type of platform
     peripheral device
     """
+
     #Device-types
     DEVICE_TYPE_PSU     = "PSU"
     DEVICE_TYPE_FAN     = "FAN"
     DEVICE_TYPE_FANDRAWER = "FAN-DRAWER"
+
+    # Possible status LED colors
+    STATUS_LED_COLOR_GREEN = "green"
+    STATUS_LED_COLOR_AMBER = "amber"
+    STATUS_LED_COLOR_RED = "red"
+    STATUS_LED_COLOR_OFF = "off"
 
     def get_name(self):
         """

--- a/sonic_platform_base/device_base.py
+++ b/sonic_platform_base/device_base.py
@@ -11,11 +11,6 @@ class DeviceBase(object):
     peripheral device
     """
 
-    #Device-types
-    DEVICE_TYPE_PSU     = "PSU"
-    DEVICE_TYPE_FAN     = "FAN"
-    DEVICE_TYPE_FANDRAWER = "FAN-DRAWER"
-
     # Possible status LED colors
     STATUS_LED_COLOR_GREEN = "green"
     STATUS_LED_COLOR_AMBER = "amber"

--- a/sonic_platform_base/fan_drawer_base.py
+++ b/sonic_platform_base/fan_drawer_base.py
@@ -81,3 +81,13 @@ class FanDrawerBase(device_base.DeviceBase):
             A string, one of the predefined STATUS_LED_COLOR_* strings above
         """
         raise NotImplementedError
+
+    def get_maximum_consumed_power(self):
+        """
+        Retrives the maximum power drawn by Fan Drawer
+
+        Returns:
+            A float, with value of the maximum consumable power of the
+            component.
+        """
+        raise NotImplementedError

--- a/sonic_platform_base/module_base.py
+++ b/sonic_platform_base/module_base.py
@@ -186,6 +186,16 @@ class ModuleBase(device_base.DeviceBase):
         """
         raise NotImplementedError
 
+    def get_maximum_consumed_power(self):
+        """
+        Retrives the maximum power drawn by this module
+
+        Returns:
+            A float, with value of the maximum consumable power of the
+            module.
+        """
+        raise NotImplementedError
+
     ##############################################
     # Component methods
     ##############################################

--- a/sonic_platform_base/psu_base.py
+++ b/sonic_platform_base/psu_base.py
@@ -219,3 +219,13 @@ class PsuBase(device_base.DeviceBase):
             e.g. 12.1 
         """
         raise NotImplementedError
+
+    def get_maximum_supplied_power(self):
+        """
+        Retrieves the maximum supplied power by PSU
+
+        Returns:
+            A float number, the maximum power output in Watts.
+            e.g. 1200.1
+        """
+        return 0.0

--- a/sonic_platform_base/psu_base.py
+++ b/sonic_platform_base/psu_base.py
@@ -15,12 +15,6 @@ class PsuBase(device_base.DeviceBase):
     # Device type definition. Note, this is a constant.
     DEVICE_TYPE = "psu"
 
-    # Possible fan status LED colors
-    STATUS_LED_COLOR_GREEN = "green"
-    STATUS_LED_COLOR_AMBER = "amber"
-    STATUS_LED_COLOR_RED = "red"
-    STATUS_LED_COLOR_OFF = "off"
-
     # List of FanBase-derived objects representing all fans
     # available on the PSU
     _fan_list = None
@@ -31,6 +25,9 @@ class PsuBase(device_base.DeviceBase):
     # and get_thermal if vendor does not call PsuBase.__init__ in concrete
     # PSU class
     _thermal_list = []
+
+    # Status of Master LED
+    psu_master_led_color = device_base.DeviceBase.STATUS_LED_COLOR_OFF
 
     def __init__(self):
         self._fan_list = []
@@ -228,4 +225,26 @@ class PsuBase(device_base.DeviceBase):
             A float number, the maximum power output in Watts.
             e.g. 1200.1
         """
-        return 0.0
+        raise NotImplementedError
+
+    @classmethod
+    def get_status_master_led(cls):
+        """
+        Gets the state of the Master status LED for a given device-type
+
+        Returns:
+            A string, one of the predefined STATUS_LED_COLOR_* strings.
+        """
+        return cls.psu_master_led_color
+
+    @classmethod
+    def set_status_master_led(cls, color):
+        """
+        Gets the state of the Master status LED for a given device-type
+
+        Returns:
+            bool: True if status LED state is set successfully, False if
+                  not
+        """
+        cls.psu_master_led_color = color
+        return True


### PR DESCRIPTION
sonic-platform-base: Changes to introduce APIs for modular chassis for power-consumption and supplied

HLD: Azure/SONiC#646

PSUd APIs for power requirement calculations

get_maximum_supplied_power() - per PSU
get_status_master_led() - get master psu led status. Class method.
set_status_master_led() - set master psu led status. Class method.

get_maximum_consumed_power(self) - per consumer API. Consumers are modules, Fans