### PR TITLE
Add unit test infrastructure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,15 @@
 *.pyc
 */__pycache__/
+tests/*.pyc
+tests/__pycache__/
+
+# Distribution / packaging
 build/
 sonic_platform_common.egg-info/
 .cache
+
+# Unit test / coverage reports
+.coverage
+htmlcov/
+
+

--- a/.gitignore
+++ b/.gitignore
@@ -11,5 +11,3 @@ sonic_platform_common.egg-info/
 # Unit test / coverage reports
 .coverage
 htmlcov/
-
-

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+addopts = --cov=sonic_platform_base --cov-report html

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[aliases]
+test=pytest

--- a/setup.py
+++ b/setup.py
@@ -40,6 +40,7 @@ setup(
     ],
     tests_require = [
         'pytest',
+        'pytest-cov',
     ],
     classifiers=[
         'Development Status :: 3 - Alpha',

--- a/setup.py
+++ b/setup.py
@@ -34,8 +34,12 @@ setup(
         'redis',
         'sonic-py-common'
     ],
-    setup_requires= [
+    setup_requires = [
+        'pytest-runner',
         'wheel'
+    ],
+    tests_require = [
+        'pytest',
     ],
     classifiers=[
         'Development Status :: 3 - Alpha',

--- a/tests/read_port_mappings_test.py
+++ b/tests/read_port_mappings_test.py
@@ -3,7 +3,7 @@ import sys
 
 try:
 
-    import sonic_platform_base.sonic_sfp.sfputilhelper 
+    import sonic_platform_base.sonic_sfp.sfputilhelper
 except Exception as e:
     print("Failed to load chassis due to {}".format(repr(e)))
 
@@ -18,7 +18,8 @@ class TestPortMappingsRead(object):
     def setup_class(cls):
         print("SETUP")
         self.test_dir = os.path.dirname(os.path.realpath(__file__))
-        self.port_config = os.path.join(self.test_dir, 't0-sample-port-config.ini')
+        self.port_config = os.path.join(
+            self.test_dir, 't0-sample-port-config.ini')
 
         self.platform_sfputil = sonic_platform_base.sonic_sfp.sfputilhelper.SfpUtilHelper()
         try:
@@ -26,26 +27,24 @@ class TestPortMappingsRead(object):
         except Exception as e:
             print("Failed to read port tab mappings to {}".format(repr(e)))
 
+    def test_port_names(self):
 
-    def test_port_names(self): 
-
-        PORT_LIST  = [ "Ethernet0",
-                       "Ethernet4",
-                       "Ethernet8",
-                       "Ethernet12",
-                       "Ethernet16",
-                       "Ethernet20",
-                       "Ethernet24",
-                       "Ethernet28",
-                       "Ethernet32",
-                       "Ethernet36",
-                       "Ethernet40",
-                       "Ethernet44",
-                       "Ethernet48"]
+        PORT_LIST = ["Ethernet0",
+                     "Ethernet4",
+                     "Ethernet8",
+                     "Ethernet12",
+                     "Ethernet16",
+                     "Ethernet20",
+                     "Ethernet24",
+                     "Ethernet28",
+                     "Ethernet32",
+                     "Ethernet36",
+                     "Ethernet40",
+                     "Ethernet44",
+                     "Ethernet48"]
         if self.platform_sfputil is not None:
             logical_port_list = self.platform_sfputil.logical
                 for logical_port_name in logical_port_list:
                     assert logical_port_name in self.port_list
         else:
             print("platform_sfputil is None, cannot read Ports")
-

--- a/tests/read_port_mappings_test.py
+++ b/tests/read_port_mappings_test.py
@@ -1,33 +1,36 @@
 import os
 import sys
 
+import pytest
 try:
-
     import sonic_platform_base.sonic_sfp.sfputilhelper
 except Exception as e:
     print("Failed to load chassis due to {}".format(repr(e)))
 
+@pytest.fixture(scope="class")
+def setup_class(request):
+    # Configure the setup
+    print("SETUP")
+    request.cls.test_dir = os.path.dirname(os.path.realpath(__file__))
+    request.cls.port_config = os.path.join(
+        request.cls.test_dir, 't0-sample-port-config.ini')
 
+    request.cls.port_config = sonic_platform_base.sonic_sfp.sfputilhelper.SfpUtilHelper()
+
+
+@pytest.mark.usefixtures("setup_class")
 class TestPortMappingsRead(object):
 
-    self.platform_sfputil = None
-    self.test_dir = None
-    self.port_config = None
+    platform_sfputil = None
+    port_config = None
+    test_dir = None
 
-    @classmethod
-    def setup_class(cls):
-        print("SETUP")
-        self.test_dir = os.path.dirname(os.path.realpath(__file__))
-        self.port_config = os.path.join(
-            self.test_dir, 't0-sample-port-config.ini')
+    def test_read_port_mappings(self):
 
-        self.platform_sfputil = sonic_platform_base.sonic_sfp.sfputilhelper.SfpUtilHelper()
         try:
             platform_sfputil.read_porttab_mappings(self.port_config, 0)
         except Exception as e:
             print("Failed to read port tab mappings to {}".format(repr(e)))
-
-    def test_port_names(self):
 
         PORT_LIST = ["Ethernet0",
                      "Ethernet4",
@@ -42,9 +45,11 @@ class TestPortMappingsRead(object):
                      "Ethernet40",
                      "Ethernet44",
                      "Ethernet48"]
+
         if self.platform_sfputil is not None:
             logical_port_list = self.platform_sfputil.logical
-                for logical_port_name in logical_port_list:
-                    assert logical_port_name in self.port_list
+            assert len(logical_port_name) == len(self.port_list)
+            for logical_port_name in logical_port_list:
+                assert logical_port_name in PORT_LIST
         else:
             print("platform_sfputil is None, cannot read Ports")

--- a/tests/read_port_mappings_test.py
+++ b/tests/read_port_mappings_test.py
@@ -1,0 +1,51 @@
+import os
+import sys
+
+try:
+
+    import sonic_platform_base.sonic_sfp.sfputilhelper 
+except Exception as e:
+    print("Failed to load chassis due to {}".format(repr(e)))
+
+
+class TestPortMappingsRead(object):
+
+    self.platform_sfputil = None
+    self.test_dir = None
+    self.port_config = None
+
+    @classmethod
+    def setup_class(cls):
+        print("SETUP")
+        self.test_dir = os.path.dirname(os.path.realpath(__file__))
+        self.port_config = os.path.join(self.test_dir, 't0-sample-port-config.ini')
+
+        self.platform_sfputil = sonic_platform_base.sonic_sfp.sfputilhelper.SfpUtilHelper()
+        try:
+            platform_sfputil.read_porttab_mappings(self.port_config, 0)
+        except Exception as e:
+            print("Failed to read port tab mappings to {}".format(repr(e)))
+
+
+    def test_port_names(self): 
+
+        PORT_LIST  = [ "Ethernet0",
+                       "Ethernet4",
+                       "Ethernet8",
+                       "Ethernet12",
+                       "Ethernet16",
+                       "Ethernet20",
+                       "Ethernet24",
+                       "Ethernet28",
+                       "Ethernet32",
+                       "Ethernet36",
+                       "Ethernet40",
+                       "Ethernet44",
+                       "Ethernet48"]
+        if self.platform_sfputil is not None:
+            logical_port_list = self.platform_sfputil.logical
+                for logical_port_name in logical_port_list:
+                    assert logical_port_name in self.port_list
+        else:
+            print("platform_sfputil is None, cannot read Ports")
+

--- a/tests/sfputilhelper_test.py
+++ b/tests/sfputilhelper_test.py
@@ -5,25 +5,24 @@ import pytest
 try:
     import sonic_platform_base.sonic_sfp.sfputilhelper
 except Exception as e:
-    print("Failed to load chassis due to {}".format(repr(e)))
+    print("Failed to load sonic_platform_base.sonic_sfp.sfputilhelper  due to {}".format(repr(e)))
+
 
 @pytest.fixture(scope="class")
 def setup_class(request):
     # Configure the setup
-    print("SETUP")
-    request.cls.test_dir = os.path.dirname(os.path.realpath(__file__))
+    test_dir = os.path.dirname(os.path.realpath(__file__))
     request.cls.port_config = os.path.join(
-        request.cls.test_dir, 't0-sample-port-config.ini')
+        test_dir, 't0-sample-port-config.ini')
 
     request.cls.port_config = sonic_platform_base.sonic_sfp.sfputilhelper.SfpUtilHelper()
 
 
 @pytest.mark.usefixtures("setup_class")
-class TestPortMappingsRead(object):
+class TestSfpUtilHelper(object):
 
     platform_sfputil = None
     port_config = None
-    test_dir = None
 
     def test_read_port_mappings(self):
 

--- a/tests/t0-sample-port-config.ini
+++ b/tests/t0-sample-port-config.ini
@@ -1,0 +1,14 @@
+# name          lanes             alias
+Ethernet0       29,30,31,32       fortyGigE0/0
+Ethernet4       25,26,27,28       fortyGigE0/4
+Ethernet8       37,38,39,40       fortyGigE0/8
+Ethernet12      33,34,35,36       fortyGigE0/12
+Ethernet16      41,42,43,44       fortyGigE0/16
+Ethernet20      45,46,47,48       fortyGigE0/20
+Ethernet24      5,6,7,8           fortyGigE0/24
+Ethernet28      1,2,3,4           fortyGigE0/28
+Ethernet32      9,10,11,12        fortyGigE0/32
+Ethernet36      13,14,15,16       fortyGigE0/36
+Ethernet40      21,22,23,24       fortyGigE0/40
+Ethernet44      17,18,19,20       fortyGigE0/44
+Ethernet48      49,50,51,52       fortyGigE0/48


### PR DESCRIPTION
Summary:
This PR provides the necessary infrastructure to add pytest support and integration in sonic-platform-common submodule.
This PR also adds the read_port_mappings_test as a pytest
### Type of change

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
Added changes in the setup.py and setup.cfg and initialized the tests directory

	new file:   setup.cfg
	modified:   setup.py
	new file:   tests/__init__.py
	new file:   tests/read_port_mappings_test.py
	new file:   tests/t0-sample-port-config.ini

#### What is the motivation for this PR?
To add the pytest support in sonic-platform-common

#### How did you do it?
Added the changes in sonic-platform-common module

#### How did you verify/test it?
run the test a part of 
make target/python-wheels/sonic_platform_common-1.0-py2-none-any.whl
make target/python-wheels/sonic_platform_common-1.0-py3-none-any.whl

Signed-off-by: vaibhav-dahiya <vdahiya@microsoft.com>
