### PR TITLE
[sonic_sfp]: Update config for multi-ASIC

### DIFF
--- a/sonic_platform_base/sonic_sfp/sfputilbase.py
+++ b/sonic_platform_base/sonic_sfp/sfputilbase.py
@@ -448,6 +448,8 @@ class SfpUtilBase(object):
                     else:
                         physical_to_logical[fp_port_index].append(intf_name)
 
+                    # Mapping of logical port names available on a system to ASIC instance
+                    self.logical_to_asic[intf_name] = asic_inst
                     port_pos_in_file +=1
 
                 self.logical = logical

--- a/sonic_platform_base/sonic_sfp/sfputilhelper.py
+++ b/sonic_platform_base/sonic_sfp/sfputilhelper.py
@@ -87,6 +87,8 @@ class SfpUtilHelper(object):
                     else:
                         physical_to_logical[fp_port_index].append(intf_name)
 
+                    # Mapping of logical port names available on a system to ASIC instance
+                    self.logical_to_asic[intf_name] = asic_inst
                     port_pos_in_file +=1
 
                 self.logical = logical


### PR DESCRIPTION
From this change https://github.com/Azure/sonic-platform-common/pull/100 , It missing mapping of logical port names to ASIC instance on device that used platform.json

So this new change will fix it by add logical_to_asic mapping dict to a condition for device that used _platform.json_

**Signed-off-by**: Wirut Getbamrung [wgetbumr@celestica.com]