### PR TITLE
[PsuBase] Reference inherited member constant

### DIFF
--- a/sonic_platform_base/psu_base.py
+++ b/sonic_platform_base/psu_base.py
@@ -27,7 +27,7 @@ class PsuBase(device_base.DeviceBase):
     _thermal_list = []
 
     # Status of Master LED
-    psu_master_led_color = device_base.DeviceBase.STATUS_LED_COLOR_OFF
+    psu_master_led_color = STATUS_LED_COLOR_OFF
 
     def __init__(self):
         self._fan_list = []


### PR DESCRIPTION
Member constant is inherited; do not need to reference into base class.