### PR TITLE
[sonic-platform-common] Fix name error and import error 

### DIFF
--- a/sonic_platform_base/psu_base.py
+++ b/sonic_platform_base/psu_base.py
@@ -27,7 +27,7 @@ class PsuBase(device_base.DeviceBase):
     _thermal_list = []
 
     # Status of Master LED
-    psu_master_led_color = device_base.DeviceBase.STATUS_LED_COLOR_OFF
+    psu_master_led_color = None
 
     def __init__(self):
         self._fan_list = []
@@ -35,6 +35,8 @@ class PsuBase(device_base.DeviceBase):
         # List of ThermalBase-derived objects representing all thermals
         # available on the PSU
         self._thermal_list = []
+
+        self.psu_master_led_color = self.STATUS_LED_COLOR_OFF
 
     def get_num_fans(self):
         """

--- a/sonic_platform_base/psu_base.py
+++ b/sonic_platform_base/psu_base.py
@@ -27,7 +27,7 @@ class PsuBase(device_base.DeviceBase):
     _thermal_list = []
 
     # Status of Master LED
-    psu_master_led_color = STATUS_LED_COLOR_OFF
+    psu_master_led_color = device_base.DeviceBase.STATUS_LED_COLOR_OFF
 
     def __init__(self):
         self._fan_list = []

--- a/sonic_platform_base/sonic_sfp/qsfp_dd.py
+++ b/sonic_platform_base/sonic_sfp/qsfp_dd.py
@@ -5,17 +5,17 @@
 from __future__ import print_function
 
 try:
-    from sff8024 import type_of_transceiver    # Dot module supports both Python 2 and Python 3 using explicit relative import methods
-    from sff8024 import type_abbrv_name    # Dot module supports both Python 2 and Python 3 using explicit relative import methods
-    from sff8024 import connector_dict    # Dot module supports both Python 2 and Python 3 using explicit relative import methods
-    from sff8024 import ext_type_of_transceiver    # Dot module supports both Python 2 and Python 3 using explicit relative import methods
-    from sff8024 import type_of_media_interface    # Dot module supports both Python 2 and Python 3 using explicit relative import methods
-    from sff8024 import host_electrical_interface    # Dot module supports both Python 2 and Python 3 using explicit relative import methods
-    from sff8024 import nm_850_media_interface    # Dot module supports both Python 2 and Python 3 using explicit relative import methods
-    from sff8024 import sm_media_interface    # Dot module supports both Python 2 and Python 3 using explicit relative import methods
-    from sff8024 import passive_copper_media_interface    # Dot module supports both Python 2 and Python 3 using explicit relative import methods
-    from sff8024 import active_cable_media_interface    # Dot module supports both Python 2 and Python 3 using explicit relative import methods
-    from sff8024 import base_t_media_interface    # Dot module supports both Python 2 and Python 3 using explicit relative import methods
+    from .sff8024 import type_of_transceiver    # Dot module supports both Python 2 and Python 3 using explicit relative import methods
+    from .sff8024 import type_abbrv_name    # Dot module supports both Python 2 and Python 3 using explicit relative import methods
+    from .sff8024 import connector_dict    # Dot module supports both Python 2 and Python 3 using explicit relative import methods
+    from .sff8024 import ext_type_of_transceiver    # Dot module supports both Python 2 and Python 3 using explicit relative import methods
+    from .sff8024 import type_of_media_interface    # Dot module supports both Python 2 and Python 3 using explicit relative import methods
+    from .sff8024 import host_electrical_interface    # Dot module supports both Python 2 and Python 3 using explicit relative import methods
+    from .sff8024 import nm_850_media_interface    # Dot module supports both Python 2 and Python 3 using explicit relative import methods
+    from .sff8024 import sm_media_interface    # Dot module supports both Python 2 and Python 3 using explicit relative import methods
+    from .sff8024 import passive_copper_media_interface    # Dot module supports both Python 2 and Python 3 using explicit relative import methods
+    from .sff8024 import active_cable_media_interface    # Dot module supports both Python 2 and Python 3 using explicit relative import methods
+    from .sff8024 import base_t_media_interface    # Dot module supports both Python 2 and Python 3 using explicit relative import methods
     from sonic_platform_base.sonic_sfp.sffbase import sffbase    # Dot module supports both Python 2 and Python 3 using explicit relative import methods
 except ImportError as e:
     raise ImportError (str(e) + "- required module not found")


### PR DESCRIPTION
Why I did this?

Found name error and import error when testing with python3 pmon daemons

How I fix this?

1. Fix name error in psu_base.py
2. change absolute import to relative import for sff8024