### PR TITLE
[sonic_eeprom] Fix variable type

### DIFF
--- a/sonic_platform_base/sonic_eeprom/eeprom_tlvinfo.py
+++ b/sonic_platform_base/sonic_eeprom/eeprom_tlvinfo.py
@@ -145,7 +145,7 @@ class TlvInfoDecoder(eeprom_base.EepromDecoder):
         not command line arguments are supplied, the user is prompted for the contents
         of the EEPROM.
         '''
-        new_tlvs = ""
+        new_tlvs = bytearray()
         (crc_is_valid, crc) = self.is_checksum_valid(e)
         if crc_is_valid:
             if self._TLV_HDR_ENABLED:


### PR DESCRIPTION
Signed-off-by: Petro Bratash <petrox.bratash@intel.com>

Fix crash in `show version` CLI command:


```
admin@sonic:~$ show version 
SONiC Software Version: SONiC.master.39-dirty-20201116.030425
Distribution: Debian 10.6
Kernel: 4.19.0-9-2-amd64
Build commit: e526d889
Build date: Mon Nov 16 06:49:50 UTC 2020
Built by: johnar@jenkins-worker-4Platform: x86_64-accton_wedge100bf_32x-r0
HwSKU: montara
ASIC: barefoot
Traceback (most recent call last):
  File "/usr/local/bin/decode-syseeprom", line 171, in <module>
    exit(main())
  File "/usr/local/bin/decode-syseeprom", line 47, in main
    t = class_('board', '','','')
  File "/usr/share/sonic/device/x86_64-accton_wedge100bf_32x-r0/plugins/eeprom.py", line 104, in __init__
    if self.eeprom_init():
  File "/usr/share/sonic/device/x86_64-accton_wedge100bf_32x-r0/plugins/eeprom.py", line 167, in eeprom_init
    new_e = eeprom_tlvinfo.TlvInfoDecoder.set_eeprom(self, "", [eeprom_params])
  File "/usr/local/lib/python2.7/dist-packages/sonic_eeprom/eeprom_tlvinfo.py", line 173, in set_eeprom
    (tlv_found, index) = self.get_tlv_index(new_tlvs, k)
  File "/usr/local/lib/python2.7/dist-packages/sonic_eeprom/eeprom_tlvinfo.py", line 454, in get_tlv_index
    if not self.is_valid_tlv(e[tlv_index:]):
  File "/usr/local/lib/python2.7/dist-packages/sonic_eeprom/eeprom_tlvinfo.py", line 255, in is_valid_tlv
    return (len(e) >= 2 and (2 + e[1] <= len(e)))
TypeError: unsupported operand type(s) for +: 'int' and 'str'
Serial Number:
............
```