### PR TITLE
Modular Chassis - Midplane monitoring APIs

### DIFF
--- a/sonic_platform_base/chassis_base.py
+++ b/sonic_platform_base/chassis_base.py
@@ -155,6 +155,20 @@ class ChassisBase(device_base.DeviceBase):
         """
         return False
 
+    def init_midplane_switch(self):
+        """
+        Initializes the midplane functionality of the modular chassis. For
+        example, any validation of midplane, populating any lookup tables etc
+        can be done here. The expectation is that the required kernel modules,
+        ip-address assignment etc are done before the pmon, database dockers
+        are up.
+
+        Returns:
+            A bool value, should return True if the midplane initialized
+            successfully.
+        """
+        return NotImplementedError
+
     ##############################################
     # Component methods
     ##############################################

--- a/sonic_platform_base/module_base.py
+++ b/sonic_platform_base/module_base.py
@@ -442,3 +442,29 @@ class ModuleBase(device_base.DeviceBase):
         """
         raise NotImplementedError
 
+    ##############################################
+    # Midplane methods for modular chassis
+    ##############################################
+    def get_midplane_ip(self):
+        """
+        Retrieves the midplane IP-address of the module in a modular chassis
+        When called from the Supervisor, the module could represent the
+        line-card and return the midplane IP-address of the line-card.
+        When called from the line-card, the module will represent the
+        Supervisor and return its midplane IP-address.
+
+        Returns:
+            A string, the IP-address of the module reachable over the midplane
+
+        """
+        return NotImplementedError
+
+    def is_midplane_reachable(self):
+        """
+        Retrieves the reachability status of the module from the Supervisor or
+        of the Supervisor from the module via the midplane of the modular chassis
+
+        Returns:
+            A bool value, should return True if module is reachable via midplane
+        """
+        return NotImplementedError


### PR DESCRIPTION
sonic-platform-base: Midplane monitoring APIs module_base.py and chassis_base.py for modular chassis

HLD: Azure/SONiC#646

- What I did
Enhance ModuleBase with new APIs to get midplane-ip-address and check-rechability
Enhance ChassisBase with new API to initialize the midplane for modular chassis

- How I did it

Add API in chassis_base.py:
```
    init_midplane_switch()
```
Add APIs in module_base.py
```
    get_midplane_ip()
    is_midplane_reachable()
```  
