### PR TITLE
[eeprom_base] Close lock file after unlocking

### DIFF
--- a/sonic_platform_base/sonic_eeprom/eeprom_base.py
+++ b/sonic_platform_base/sonic_eeprom/eeprom_base.py
@@ -300,6 +300,7 @@ class EepromDecoder(object):
         if self.cache_update_needed:
             self.write_cache(e)
         fcntl.flock(self.lock_file, fcntl.LOCK_UN)
+        self.lock_file.close()
 
     def update_eeprom_db(self, e):
         return 0


### PR DESCRIPTION
Close EEPROM lock file after unlocking. Python 3 now outputs warnings such as the following to stderr if a file descriptor is left open:

```
/usr/local/bin/decode-syseeprom:171 : ResourceWarning : unclosed file <_io.TextIOWrapper name='/var/run/hw-management/eeprom/vpd_info' mode='r' encoding='UTF-8'>
```

With this change, the above warning is no longer displayed.