### PR TITLE
[sonic_y_cable] add check_mux_direction api for y_cable

### DIFF
--- a/sonic_y_cable/y_cable.py
+++ b/sonic_y_cable/y_cable.py
@@ -177,9 +177,9 @@ def check_read_side(physical_port):
     else:
         helper_logger.log_error(
             "Error: unknown status for checking which side regval = {} ".format(result))
-        return -1
 
     return -1
+
 
 def check_mux_direction(physical_port):
     """

--- a/sonic_y_cable/y_cable.py
+++ b/sonic_y_cable/y_cable.py
@@ -191,7 +191,7 @@ def check_mux_direction(physical_port):
     Register Specification of upper page 0x4 at offset 133 is documented below
 
     Byte offset   bits     Name                           Description
-    133           7-0      MUX Switch Status Register     0x00 : MUX pointing at TOR#2, 0x01 MUX pointing at TOR#1 regardless of connection status
+    132           7-0      MUX Switch Status Register     0x00 : MUX pointing at TOR#2, 0x01 MUX pointing at TOR#1 regardless of connection status
 
     Args:
          physical_port:


### PR DESCRIPTION
Summary:
This PR provides the support for checking the mux_direction on the y_cable by checking the mux_direction register

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
added the changes in y_cable.py with register specification for check_mux_direction

#### What is the motivation for this PR?
check_mux_direction is required for y_cable_utilities to replace the active_linked_tor_side -> check_mux_direction as agreed as a part of design

#### How did you do it?
added the API definition

#### How did you verify/test it?
Ran the pmon docker with the changed file, and redis-cli to obtain the events and check the functionality is working, also confirmed the same with i2c commands by toggling the mux


Signed-off-by: vaibhav-dahiya <vdahiya@microsoft.com>