### PR TITLE
Make eeprom_tlvinfo.py Python3 compatible

### DIFF
--- a/sonic_platform_base/sonic_eeprom/eeprom_tlvinfo.py
+++ b/sonic_platform_base/sonic_eeprom/eeprom_tlvinfo.py
@@ -202,16 +202,16 @@ class TlvInfoDecoder(eeprom_base.EepromDecoder):
 
         if self._TLV_HDR_ENABLED:
             new_tlvs_len = len(new_tlvs) + 6
-            new_e = self._TLV_INFO_ID_STRING + chr(self._TLV_INFO_VERSION) + \
-                    chr((new_tlvs_len >> 8) & 0xFF) + \
-                    chr(new_tlvs_len & 0xFF) + new_tlvs
+            new_e = self._TLV_INFO_ID_STRING + bytes([self._TLV_INFO_VERSION]) + \
+                    bytes([(new_tlvs_len >> 8) & 0xFF]) + \
+                    bytes([new_tlvs_len & 0xFF]) + new_tlvs
         else:
             new_e = new_tlvs
 
         if self._TLV_CODE_CRC_32 != self._TLV_CODE_UNDEFINED:
-            new_e = new_e + chr(self._TLV_CODE_CRC_32) + chr(4)
+            new_e = new_e + bytes([self._TLV_CODE_CRC_32]) + bytes([4])
         elif self._TLV_CODE_QUANTA_CRC != self._TLV_CODE_UNDEFINED:
-            new_e = new_e + chr(self._TLV_CODE_QUANTA_CRC) + chr(2)
+            new_e = new_e + bytes([self._TLV_CODE_QUANTA_CRC]) + bytes([2])
         else:
             print("\nFailed to formulate new eeprom\n")
             exit
@@ -682,7 +682,7 @@ class TlvInfoDecoder(eeprom_base.EepromDecoder):
                 sys.stderr.write("Error: '" + "0x%02X" % (I[0],) + "' correct format is " + errstr + "\n")
             exit(0)
 
-        return chr(I[0]) + chr(len(value)) + value
+        return (chr(I[0]) + chr(len(value)) + value).encode()
 
 
     def is_checksum_field(self, I):


### PR DESCRIPTION
Fix errors like below:
```
admin@sonic:~$ show version 

SONiC Software Version: SONiC.master.0-dirty-20201204.005739
Distribution: Debian 10.6
Kernel: 4.19.0-9-2-amd64
Build commit: 873fb969
Build date: Fri Dec  4 09:02:43 UTC 2020
Built by: user@sonic-build

Platform: x86_64-accton_wedge100bf_32x-r0
HwSKU: montara
ASIC: barefoot
Traceback (most recent call last):
  File "/usr/local/bin/decode-syseeprom", line 171, in <module>
    exit(main())
  File "/usr/local/bin/decode-syseeprom", line 47, in main
    t = class_('board', '','','')
  File "/usr/share/sonic/device/x86_64-accton_wedge100bf_32x-r0/plugins/eeprom.py", line 113, in __init__
    if self.eeprom_init():
  File "/usr/share/sonic/device/x86_64-accton_wedge100bf_32x-r0/plugins/eeprom.py", line 180, in eeprom_init
    self, "", [eeprom_params])
  File "/usr/local/lib/python3.7/dist-packages/sonic_eeprom/eeprom_tlvinfo.py", line 178, in set_eeprom
    new_tlvs += new_tlv
TypeError: can't concat str to bytearray
```

