### PR TITLE
[sonic_y_cable] Add support for measuring BER and EYE scan and running Loopback, PRBS modes on the Y cable

### DIFF
--- a/sonic_y_cable/y_cable.py
+++ b/sonic_y_cable/y_cable.py
@@ -10,7 +10,7 @@ try:
     import sonic_platform.platform
 except ImportError as e:
     # When build python3 xcvrd, it tries to do basic check which will import this file. However,
-    # not all platform supports python3 API now, so it could cause an issue when importing 
+    # not all platform supports python3 API now, so it could cause an issue when importing
     # sonic_platform.platform. We skip the ImportError here. This is safe because:
     #   1. If any python package is not available, there will be exception when use it
     #   2. Vendors know their platform API version, they are responsible to use correct python
@@ -28,6 +28,16 @@ Y_CABLE_SWITCH_MUX_DIRECTION = 642
 Y_CABLE_MUX_DIRECTION = 644
 Y_CABLE_ACTIVE_TOR_INDICATOR = 645
 Y_CABLE_MANUAL_SWITCH_COUNT = 669
+Y_CABLE_CONFIGURE_PRBS_TYPE = 768
+Y_CABLE_ENABLE_PRBS = 769
+Y_CABLE_INITIATE_BER_MEASUREMENT = 770
+Y_CABLE_TARGET =794
+Y_CABLE_ENABLE_LOOPBACK =793
+Y_CABLE_LANE_1_BER_RESULT =771
+Y_CABLE_MAX_LANES =2
+Y_CABLE_INITIATE_EYE_MEASUREMENT =788
+Y_CABLE_LANE_1_EYE_RESULT =789
+
 
 SYSLOG_IDENTIFIER = "sonic_y_cable"
 
@@ -504,6 +514,389 @@ def check_if_link_is_active_for_torB(physical_port):
 
     if ((regval_read[0] >> 1) & 0x01):
         helper_logger.log_info("TOR B link is up")
+        return True
+    else:
+        return False
+
+@hook_y_cable_simulator
+def enable_PRBS_mode(physical_port, target, mode_value, laneMap):
+    """
+    This API specifically configures and enables the PRBS mode/type depending upon the mode_value the user provides.
+    The mode_value configures the PRBS Type for generation and BER sensing on a per side basis.  Each side can only R/W its own value.  0x00 = PRBS 9, 0x01 = PRBS 15, 0x02 = PRBS 23, 0x03 = PRBS 31, 0x04-0xFF reserved. Target is an integer for selecting which end of the Y cable we want to run PRBS on. LaneMap specifies the lane configuration to run the PRBS on.
+
+
+    Register Specification of upper page 0x5 at offset 128, 129 is documented below
+
+    Byte offset   bits    Name                  Description
+    128           7-0     Reserved              PRBS Type for generation and BER sensing on a per side basis.  Each side can only R/W its own value.  0x00 = PRBS 9, 0x01 = PRBS 15, 0x02 = PRBS 23, 0x03 = PRBS 31, 0x04-0xFF reserved
+
+    129           7-4     Reserved
+                  3       Lane 4 enable         "Enable PRBS generation on target lane 0b1 : Enable, 0b0 disable If any lanes are enabled, then that side of cable is removed fro mission mode and no longer passing valid traffic."
+                  2       Lane 3 enable
+                  1       Lane 2 enable
+                  0       Lane 1 enable
+
+    Args:
+        physical_port:
+             an Integer, the actual physical port connected to a Y cable
+        target:
+             an Integer, the target on which to enable the PRBS
+                         0 -> local side,
+                         1 -> TOR 1
+                         2 -> TOR 2
+                         3 -> NIC
+        mode_value:
+             an Integer, the mode/type for configuring the PRBS mode.
+             0x00 = PRBS 9, 0x01 = PRBS 15, 0x02 = PRBS 23, 0x03 = PRBS 31
+        laneMap:
+             an Integer, representing the laneMap to be run PRBS on
+             0bit for lane 0, 1bit for lane1 and so on.
+             for example 3 -> 0b'0011 , means running on lane0 and lane1
+
+    Returns:
+        a boolean, true if the enable is successful
+                 , false if the enable failed
+    """
+
+    buffer = bytearray([target])
+    curr_offset = Y_CABLE_TARGET
+
+    if platform_chassis is not None:
+        result = platform_chassis.get_sfp(
+            physical_port).write_eeprom(curr_offset, 1, buffer)
+        if result is False:
+            return result
+        buffer = bytearray([mode_value])
+        curr_offset = Y_CABLE_CONFIGURE_PRBS_TYPE
+        result = platform_chassis.get_sfp(
+            physical_port).write_eeprom(curr_offset, 1, buffer)
+        if result is False:
+            return result
+        buffer = bytearray([laneMap])
+        curr_offset = Y_CABLE_ENABLE_PRBS
+        result = platform_chassis.get_sfp(
+            physical_port).write_eeprom(curr_offset, 1, buffer)
+
+    else:
+        helper_logger.log_error("platform_chassis is not loaded, failed to configure the PRBS type")
+        return -1
+
+    return result
+
+@hook_y_cable_simulator
+def enable_Loopback_mode(physical_port, target, laneMap):
+    """
+    This API specifically configures and enables the Loopback mode on the port user provides.
+    Target is an integer for selecting which end of the Y cable we want to run loopback on. LaneMap specifies the lane configuration to run the loopback on.
+
+
+    Register Specification of upper page 0x5 at offset 153 is documented below
+
+    Byte offset   bits    Name                  Description
+    153           7-4                           Reserved
+                  3     Lane 4 enable           "Enable loopback generation on target lane 0b1 : Enable, 0b0 disable.The cable supports 3 modes of operation : mission mode; PRBS mode or loopback mode.  Enabling loopback on any lane of any sides puts cable in loopback mode and disables PRBS.
+                  2     Lane 3 enable
+                  1     Lane 2 enable
+                  0     Lane 1 enable
+
+    Args:
+        physical_port:
+             an Integer, the actual physical port connected to a Y cable
+        target:
+             an Integer, the target on which to enable the PRBS
+                         0 -> local side,
+                         1 -> TOR 1
+                         2 -> TOR 2
+                         3 -> NIC
+        laneMap:
+             an Integer, representing the laneMap to be run PRBS on
+             0bit for lane 0, 1bit for lane1 and so on.
+             for example 3 -> 0b'0011 , means running on lane0 and lane1
+
+    Returns:
+        a boolean, true if the enable is successful
+                 , false if the enable failed
+    """
+
+    buffer = bytearray([target])
+    curr_offset = Y_CABLE_TARGET
+
+    if platform_chassis is not None:
+        result = platform_chassis.get_sfp(
+            physical_port).write_eeprom(curr_offset, 1, buffer)
+        if result is False:
+            return result
+        buffer = bytearray([laneMap])
+        curr_offset = Y_CABLE_ENABLE_LOOPBACK
+        result = platform_chassis.get_sfp(
+            physical_port).write_eeprom(curr_offset, 1, buffer)
+
+    else:
+        helper_logger.log_error("platform_chassis is not loaded, failed to configure the PRBS type")
+        return -1
+
+    return result
+
+@hook_y_cable_simulator
+def Get_BER_info(physical_port, target):
+    """
+    This API specifically returns the BER(Bit error rate) value for a specfic port.
+    The target could be local side, TOR1, TOR2, NIC etc.
+
+
+    Register Specification of upper page 0x5 at offset 130 is documented below
+
+    Byte offset   bits    Name                     Description
+    130           1-0     Initiate BER Measurement "Write 0x00 - initiate gated BER measurement on target side with PRBS traffic
+                                                    Write 0x01-0xFF - reserved
+                                                    Read 0x00 - BER Gate in process
+                                                    Read 0x01 - BER Gate complete, valid values in Lane BER registers
+                                                    NB this command is only valid when PRBS has been enabled on at least one lane
+                                                    The cable supports 3 modes of operation : mission mode; PRBS mode or loopback mode.
+                                                    Enabling PRBS on any lane of any sides puts cable in PRBS mode and disables loopback and mission mode."
+
+    Args:
+        physical_port:
+             an Integer, the actual physical port connected to a Y cable
+        target:
+             an Integer, the target on which to enable the PRBS
+                         0 -> local side,
+                         1 -> TOR 1
+                         2 -> TOR 2
+                         3 -> NIC
+    Returns:
+        a list, with BER values of lane 0 and lane 1 with corresponding index
+    """
+
+    buffer = bytearray([target])
+    curr_offset = Y_CABLE_TARGET
+
+    result = []
+
+    if platform_chassis is not None:
+        result = platform_chassis.get_sfp(
+            physical_port).write_eeprom(curr_offset, 1, buffer)
+        if result is False:
+            return result
+        buffer = bytearray([laneMap])
+        curr_offset = Y_CABLE_INITIATE_BER_MEASUREMENT
+        result = platform_chassis.get_sfp(
+            physical_port).write_eeprom(curr_offset, 1, buffer)
+        while(1):
+            done = platform_chassis.get_sfp(physical_port).read_eeprom(curr_offset, 1, buffer)
+            if done == 1: break
+
+        idx = 0
+        maxLane = 2
+        for lane in range(maxLane):
+            curr_offset = Y_CABLE_LANE_1_BER_RESULT
+            msb = platform_chassis.get_sfp(physical_port).read_eeprom(curr_offset+idx, 1, buffer)
+            msb = platform_chassis.get_sfp(physical_port).read_eeprom(curr_offset+1+idx, 1, buffer)
+            lane_result = msb * math.pow(10, (lsb-24))
+            result.append(lane_result)
+            #print('[%s] lane[%1d] BER[%e]' % (targetDes[target], lane + 1, result))
+            idx += 2
+
+    else:
+        helper_logger.log_error("platform_chassis is not loaded, failed to configure the PRBS type")
+        return -1
+
+    return result
+
+@hook_y_cable_simulator
+def Get_EYE_info(physical_port, target):
+    """
+    This API specifically returns the EYE height value for a specfic port.
+    The target could be local side, TOR1, TOR2, NIC etc.
+
+
+    Register Specification of upper page 0x5 at offset 144 is documented below
+
+    Byte offset   bits    Name                     Description
+    144           1-0     Initiate EYE Measurement "Write 0x00 - initiate gated eye height measurement on target side with any traffic (PRBS or mission mode)
+                                                    Write 0x01-0xFF - reserved
+                                                    Read 0x00 - Eye Height Measurement in process
+                                                    Read 0x01 - Eye Height Gate complete, valid values in Eye Height Registers
+                                                    NB this command can be issued whenever the side is linked, this does not interrupt mission mode traffic"	R/W
+
+    Args:
+        physical_port:
+             an Integer, the actual physical port connected to a Y cable
+        target:
+             an Integer, the target on which to enable the PRBS
+                         0 -> local side,
+                         1 -> TOR 1
+                         2 -> TOR 2
+                         3 -> NIC
+    Returns:
+        a list, with EYE values of lane 0 and lane 1 with corresponding index
+    """
+
+    buffer = bytearray([target])
+    curr_offset = Y_CABLE_TARGET
+
+    result = []
+
+    if platform_chassis is not None:
+        result = platform_chassis.get_sfp(
+            physical_port).write_eeprom(curr_offset, 1, buffer)
+        if result is False:
+            return result
+        buffer = bytearray([laneMap])
+        curr_offset =  Y_CABLE_INITIATE_EYE_MEASUREMENT
+        result = platform_chassis.get_sfp(
+            physical_port).write_eeprom(curr_offset, 1, buffer)
+        while(1):
+            done = platform_chassis.get_sfp(physical_port).read_eeprom(curr_offset, 1, buffer)
+            if done == 1: break
+
+        idx = 0
+        maxLane = 2
+        for lane in range(maxLane):
+            curr_offset = Y_CABLE_LANE_1_EYE_RESULT
+            msb = platform_chassis.get_sfp(physical_port).read_eeprom(curr_offset+idx, 1, buffer)
+            msb = platform_chassis.get_sfp(physical_port).read_eeprom(curr_offset+1+idx, 1, buffer)
+            lane_result = (msb << 8 | lsb)
+            result.append(lane_result)
+            #print('[%s] lane[%1d] BER[%e]' % (targetDes[target], lane + 1, result))
+            idx += 2
+
+    else:
+        helper_logger.log_error("platform_chassis is not loaded, failed to configure the PRBS type")
+        return -1
+
+    return result
+
+@hook_y_cable_simulator
+def enable_PRBS_per_port_lane(physical_port, lane_number):
+    """
+    This API specifically enables the PRBS on the lane number user provides.
+    The lane_number specifies on which lane the PRBS will be enabled.
+    Note that this API if enabled for any lane will specifically stop the mission mode traffic, and start PRBS internal traffic.
+
+    Register Specification of upper page 0x5 at offset 129 is documented below
+
+    Byte offset   bits    Name                  Description
+    129           7-4                           Reserved
+                  3     Lane 4 enable           "Enable PRBS generation on target lane 0b1 : Enable, 0b0 disable If any lanes are enabled, then that side of cable is removed fro mission mode and no longer passing valid traffic."
+                  2     Lane 3 enable
+                  1     Lane 2 enable
+                  0     Lane 1 enable
+
+
+    Args:
+        physical_port:
+             an Integer, the actual physical port connected to a Y cable
+             an Integer, the lane on which PRBS has to be enabled.
+
+    Returns:
+        a boolean, true if the PRBS enable is successful
+                 , false if the PRBS config is failed
+    """
+
+    buffer = bytearray([1<<lane_number])
+    curr_offset = Y_CABLE_ENABLE_PRBS
+
+    if platform_chassis is not None:
+        result = platform_chassis.get_sfp(
+            physical_port).write_eeprom(curr_offset, 1, buffer)
+    else:
+        helper_logger.log_error("platform_chassis is not loaded, failed to configure the PRBS type")
+        return -1
+
+    return result
+
+@hook_y_cable_simulator
+def initiate_BER_measurement(physical_port):
+    """
+    This API specifically enables the BER measurement when the PRBS is enabled on any lane
+
+    Register Specification of upper page 0x5 at offset 130 is documented below
+
+    Byte offset   bits    Name                     Description
+    130           1-0     Initiate BER Measurement "Write 0x00 - initiate gated BER measurement on target side with PRBS traffic
+                                                    Write 0x01-0xFF - reserved
+                                                    Read 0x00 - BER Gate in process
+                                                    Read 0x01 - BER Gate complete, valid values in Lane BER registers
+                                                    NB this command is only valid when PRBS has been enabled on at least one lane
+                                                    The cable supports 3 modes of operation : mission mode; PRBS mode or loopback mode.
+                                                    Enabling PRBS on any lane of any sides puts cable in PRBS mode and disables loopback and mission mode."
+
+    Args:
+        physical_port:
+             an Integer, the actual physical port connected to a Y cable
+
+    Returns:
+        a boolean, true if the BER initiate is successful
+                 , false if the BER initiation failed
+    """
+
+    buffer = bytearray([0])
+    curr_offset = Y_CABLE_INITIATE_BER_MEASUREMENT
+
+    if platform_chassis is not None:
+        result = platform_chassis.get_sfp(
+            physical_port).write_eeprom(curr_offset, 1, buffer)
+    else:
+        helper_logger.log_error("platform_chassis is not loaded, failed to configure the PRBS type")
+        return -1
+
+    return result
+
+@hook_y_cable_simulator
+def check_if_BER_initiation_complete(physical_port):
+    """
+    This API specifically checks if the BER measurement is available when the PRBS is enabled on any lane
+
+    Register Specification of upper page 0x5 at offset 130 is documented below
+
+    Byte offset   bits    Name                     Description
+    130           1-0     Initiate BER Measurement "Write 0x00 - initiate gated BER measurement on target side with PRBS traffic
+                                                    Write 0x01-0xFF - reserved
+                                                    Read 0x00 - BER Gate in process
+                                                    Read 0x01 - BER Gate complete, valid values in Lane BER registers
+                                                    NB this command is only valid when PRBS has been enabled on at least one lane
+                                                    The cable supports 3 modes of operation : mission mode; PRBS mode or loopback mode.
+                                                    Enabling PRBS on any lane of any sides puts cable in PRBS mode and disables loopback and mission mode."
+
+    Args:
+        physical_port:
+             an Integer, the actual physical port connected to a Y cable
+
+    Returns:
+        a boolean, true if the BER is ready to be read
+                 , false if the BER is not ready to be read
+    """
+
+    buffer = bytearray([0])
+    curr_offset = Y_CABLE_INITIATE_BER_MEASUREMENT
+
+    if platform_chassis is not None:
+        result = platform_chassis.get_sfp(
+            physical_port).read_eeprom(curr_offset, 1)
+    else:
+        helper_logger.log_error("platform_chassis is not loaded, failed to check if link is Active on TOR A side")
+        return -1
+
+    if result is not None:
+        if isinstance(result, bytearray):
+            if len(result) != 1:
+                helper_logger.log_error("Error: for checking if BER is ready to be read, eeprom returned a size {} not equal to 1 for port {}".format(
+                    len(result), physical_port))
+                return -1
+        else:
+            helper_logger.log_error("Error: for checking if BER is ready to be read, eeprom read returned an instance value of type {} which is not a bytearray for port {}".format(
+                type(result), physical_port))
+            return -1
+    else:
+        helper_logger.log_error(
+            "Error: for checking if BER is ready to be read, eeprom read returned a None value from eeprom read for port {} which is not expected".format(physical_port))
+        return -1
+
+    regval_read = struct.unpack(">B", result)
+
+    if ((regval_read[0]) & 0x01):
+        helper_logger.log_info("BER is available to be read")
         return True
     else:
         return False

--- a/sonic_y_cable/y_cable.py
+++ b/sonic_y_cable/y_cable.py
@@ -56,7 +56,6 @@ Y_CABLE_EYE_PRBS_TARGET_TOR1 = 1
 Y_CABLE_EYE_PRBS_TARGET_TOR2 = 2
 Y_CABLE_EYE_PRBS_TARGET_NIC = 3
 
-
 SYSLOG_IDENTIFIER = "sonic_y_cable"
 
 # Global logger instance for helper functions and classes to log

--- a/sonic_y_cable/y_cable.py
+++ b/sonic_y_cable/y_cable.py
@@ -48,9 +48,9 @@ Y_CABLE_NIC_CURSOR_VALUES = 661
 Y_CABLE_TOR1_CURSOR_VALUES = 681
 Y_CABLE_TOR2_CURSOR_VALUES = 701
 Y_CABLE_NIC_LANE_ACTIVE = 721
-Y_CABLE_COUNT_TARGET_NIC = 0
-Y_CABLE_COUNT_TARGET_TOR1 = 1
-Y_CABLE_COUNT_TARGET_TOR2 = 2
+Y_CABLE_TARGET_NIC = 0
+Y_CABLE_TARGET_TOR1 = 1
+Y_CABLE_TARGET_TOR2 = 2
 Y_CABLE_EYE_PRBS_TARGET_LOCAL = 0
 Y_CABLE_EYE_PRBS_TARGET_TOR1 = 1
 Y_CABLE_EYE_PRBS_TARGET_TOR2 = 2
@@ -1023,9 +1023,9 @@ def get_target_cursor_values(physical_port, lane, target):
                          4 -> lane 4
         target:
              an Integer, the actual target to get the cursor values on
-                         Y_CABLE_COUNT_TARGET_NIC -> NIC,
-                         Y_CABLE_COUNT_TARGET_TOR1-> TOR1,
-                         Y_CABLE_COUNT_TARGET_TOR2 -> TOR2
+                         Y_CABLE_TARGET_NIC -> NIC,
+                         Y_CABLE_TARGET_TOR1-> TOR1,
+                         Y_CABLE_TARGET_TOR2 -> TOR2
     Returns:
         an list, with  pre one, pre two , main, post one, post two cursor values in the order
     """

--- a/sonic_y_cable/y_cable.py
+++ b/sonic_y_cable/y_cable.py
@@ -62,16 +62,16 @@ def y_cable_validate_read_data(result, size, physical_port, message):
     if result is not None:
         if isinstance(result, bytearray):
             if len(result) != size:
-                helper_logger.log_error("Error: for checking mux_cable {}, eeprom read returned a size {} not equal to 1 for port {}".format(message,
-                                                                                                                                             len(result), physical_port))
+                LOG_MESSAGE_TEMPLATE = "Error: for checking mux_cable {}, eeprom read returned a size {} not equal to 1 for port {}"
+                helper_logger.log_error(LOG_MESSAGE_TEMPLATE.format(message, len(result), physical_port))
                 return -1
         else:
-            helper_logger.log_error("Error: for checking mux_cable {}, eeprom read returned an instance value of type {} which is not a bytearray for port {}".format(message,
-                                                                                                                                                                      type(result), physical_port))
+            LOG_MESSAGE_TEMPLATE = "Error: for checking mux_cable {}, eeprom read returned an instance value of type {} which is not a bytearray for port {}"
+            helper_logger.log_error(LOG_MESSAGE_TEMPLATE.format(message, type(result), physical_port))
             return -1
     else:
-        helper_logger.log_error(
-            "Error: for checking mux_cable {}, eeprom read returned a None value for port {} which is not expected".format(message, physical_port))
+        LOG_MESSAGE_TEMPLATE = "Error: for checking mux_cable {}, eeprom read returned a None value for port {} which is not expected"
+        helper_logger.log_error(LOG_MESSAGE_TEMPLATE.format(message, physical_port))
         return -1
 
 

--- a/sonic_y_cable/y_cable.py
+++ b/sonic_y_cable/y_cable.py
@@ -777,7 +777,7 @@ def disable_loopback_mode(physical_port, target):
 @hook_y_cable_simulator
 def get_ber_info(physical_port, target):
     """
-    This API specifically returns the BER(Bit error rate) value for a specfic port.
+    This API specifically returns the BER (Bit error rate) value for a specfic port.
     The target could be local side, TOR1, TOR2, NIC etc.
 
 

--- a/sonic_y_cable/y_cable.py
+++ b/sonic_y_cable/y_cable.py
@@ -8,7 +8,6 @@ try:
     import struct
     from sonic_py_common import logger
     import sonic_platform.platform
-    import binascii
     import math
 except ImportError as e:
     # When build python3 xcvrd, it tries to do basic check which will import this file. However,
@@ -33,12 +32,12 @@ Y_CABLE_MANUAL_SWITCH_COUNT = 669
 Y_CABLE_CONFIGURE_PRBS_TYPE = 768
 Y_CABLE_ENABLE_PRBS = 769
 Y_CABLE_INITIATE_BER_MEASUREMENT = 770
-Y_CABLE_TARGET =794
-Y_CABLE_ENABLE_LOOPBACK =793
-Y_CABLE_LANE_1_BER_RESULT =771
-Y_CABLE_MAX_LANES =2
-Y_CABLE_INITIATE_EYE_MEASUREMENT =784
-Y_CABLE_LANE_1_EYE_RESULT =785
+Y_CABLE_TARGET = 794
+Y_CABLE_ENABLE_LOOPBACK = 793
+Y_CABLE_LANE_1_BER_RESULT = 771
+Y_CABLE_MAX_LANES = 2
+Y_CABLE_INITIATE_EYE_MEASUREMENT = 784
+Y_CABLE_LANE_1_EYE_RESULT = 785
 
 
 SYSLOG_IDENTIFIER = "sonic_y_cable"
@@ -62,11 +61,11 @@ def y_cable_validate_read_data(result, size, physical_port, message):
         if isinstance(result, bytearray):
             if len(result) != size:
                 helper_logger.log_error("Error: for checking mux_cable {}, eeprom read returned a size {} not equal to 1 for port {}".format(message,
-                    len(result), physical_port))
+                                                                                                                                             len(result), physical_port))
                 return -1
         else:
             helper_logger.log_error("Error: for checking mux_cable {}, eeprom read returned an instance value of type {} which is not a bytearray for port {}".format(message,
-                type(result), physical_port))
+                                                                                                                                                                      type(result), physical_port))
             return -1
     else:
         helper_logger.log_error(
@@ -538,20 +537,28 @@ def check_if_link_is_active_for_torB(physical_port):
     else:
         return False
 
+
 @hook_y_cable_simulator
-def enable_prbs_mode(physical_port, target, mode_value, laneMap):
+def enable_prbs_mode(physical_port, target, mode_value, lane_map):
     """
     This API specifically configures and enables the PRBS mode/type depending upon the mode_value the user provides.
-    The mode_value configures the PRBS Type for generation and BER sensing on a per side basis.  Each side can only R/W its own value.  0x00 = PRBS 9, 0x01 = PRBS 15, 0x02 = PRBS 23, 0x03 = PRBS 31, 0x04-0xFF reserved. Target is an integer for selecting which end of the Y cable we want to run PRBS on. LaneMap specifies the lane configuration to run the PRBS on.
+    The mode_value configures the PRBS Type for generation and BER sensing on a per side basis.
+    Each side can only R/W its own value.  0x00 = PRBS 9, 0x01 = PRBS 15, 0x02 = PRBS 23, 0x03 = PRBS 31, 0x04-0xFF reserved.
+    Target is an integer for selecting which end of the Y cable we want to run PRBS on.
+    LaneMap specifies the lane configuration to run the PRBS on.
 
 
     Register Specification of upper page 0x5 at offset 128, 129 is documented below
 
     Byte offset   bits    Name                  Description
-    128           7-0     Reserved              PRBS Type for generation and BER sensing on a per side basis.  Each side can only R/W its own value.  0x00 = PRBS 9, 0x01 = PRBS 15, 0x02 = PRBS 23, 0x03 = PRBS 31, 0x04-0xFF reserved
+    128           7-0     Reserved              PRBS Type for generation and BER sensing on a per side basis.
+                                                Each side can only R/W its own value.
+                                                0x00 = PRBS 9, 0x01 = PRBS 15, 0x02 = PRBS 23, 0x03 = PRBS 31, 0x04-0xFF reserved
 
     129           7-4     Reserved
-                  3       Lane 4 enable         "Enable PRBS generation on target lane 0b1 : Enable, 0b0 disable If any lanes are enabled, then that side of cable is removed fro mission mode and no longer passing valid traffic."
+                  3       Lane 4 enable         "Enable PRBS generation on target lane 0b1 :
+                                                 Enable, 0b0 disable If any lanes are enabled,
+                                                 then that side of cable is removed fro mission mode and no longer passing valid traffic."
                   2       Lane 3 enable
                   1       Lane 2 enable
                   0       Lane 1 enable
@@ -568,8 +575,8 @@ def enable_prbs_mode(physical_port, target, mode_value, laneMap):
         mode_value:
              an Integer, the mode/type for configuring the PRBS mode.
              0x00 = PRBS 9, 0x01 = PRBS 15, 0x02 = PRBS 23, 0x03 = PRBS 31
-        laneMap:
-             an Integer, representing the laneMap to be run PRBS on
+        lane_map:
+             an Integer, representing the lane_map to be run PRBS on
              0bit for lane 0, 1bit for lane1 and so on.
              for example 3 -> 0b'0011 , means running on lane0 and lane1
 
@@ -592,7 +599,7 @@ def enable_prbs_mode(physical_port, target, mode_value, laneMap):
             physical_port).write_eeprom(curr_offset, 1, buffer)
         if result is False:
             return result
-        buffer = bytearray([laneMap])
+        buffer = bytearray([lane_map])
         curr_offset = Y_CABLE_ENABLE_PRBS
         result = platform_chassis.get_sfp(
             physical_port).write_eeprom(curr_offset, 1, buffer)
@@ -603,6 +610,7 @@ def enable_prbs_mode(physical_port, target, mode_value, laneMap):
 
     return result
 
+
 @hook_y_cable_simulator
 def disable_prbs_mode(physical_port, target):
     """
@@ -612,7 +620,9 @@ def disable_prbs_mode(physical_port, target):
 
     Byte offset   bits    Name                  Description
     129           7-4     Reserved
-                  3       Lane 4 enable         "Enable PRBS generation on target lane 0b1 : Enable, 0b0 disable If any lanes are enabled, then that side of cable is removed fro mission mode and no longer passing valid traffic."
+                  3       Lane 4 enable         "Enable PRBS generation on target lane 0b1 :
+                                                 Enable, 0b0 disable If any lanes are enabled,
+                                                 then that side of cable is removed fro mission mode and no longer passing valid traffic."
                   2       Lane 3 enable
                   1       Lane 2 enable
                   0       Lane 1 enable
@@ -651,18 +661,22 @@ def disable_prbs_mode(physical_port, target):
 
     return result
 
+
 @hook_y_cable_simulator
-def enable_loopback_mode(physical_port, target, laneMap):
+def enable_loopback_mode(physical_port, target, lane_map):
     """
     This API specifically configures and enables the Loopback mode on the port user provides.
-    Target is an integer for selecting which end of the Y cable we want to run loopback on. LaneMap specifies the lane configuration to run the loopback on.
+    Target is an integer for selecting which end of the Y cable we want to run loopback on.
+    LaneMap specifies the lane configuration to run the loopback on.
 
 
     Register Specification of upper page 0x5 at offset 153 is documented below
 
     Byte offset   bits    Name                  Description
     153           7-4                           Reserved
-                  3     Lane 4 enable           "Enable loopback generation on target lane 0b1 : Enable, 0b0 disable.The cable supports 3 modes of operation : mission mode; PRBS mode or loopback mode.  Enabling loopback on any lane of any sides puts cable in loopback mode and disables PRBS.
+                  3     Lane 4 enable           "Enable loopback generation on target lane 0b1 :
+                                                 Enable, 0b0 disable.The cable supports 3 modes of operation : mission mode; PRBS mode or loopback mode.
+                                                 Enabling loopback on any lane of any sides puts cable in loopback mode and disables PRBS.
                   2     Lane 3 enable
                   1     Lane 2 enable
                   0     Lane 1 enable
@@ -676,8 +690,8 @@ def enable_loopback_mode(physical_port, target, laneMap):
                          1 -> TOR 1
                          2 -> TOR 2
                          3 -> NIC
-        laneMap:
-             an Integer, representing the laneMap to be run PRBS on
+        lane_map:
+             an Integer, representing the lane_map to be run PRBS on
              0bit for lane 0, 1bit for lane1 and so on.
              for example 3 -> 0b'0011 , means running on lane0 and lane1
 
@@ -694,7 +708,7 @@ def enable_loopback_mode(physical_port, target, laneMap):
             physical_port).write_eeprom(curr_offset, 1, buffer)
         if result is False:
             return result
-        buffer = bytearray([laneMap])
+        buffer = bytearray([lane_map])
         curr_offset = Y_CABLE_ENABLE_LOOPBACK
         result = platform_chassis.get_sfp(
             physical_port).write_eeprom(curr_offset, 1, buffer)
@@ -704,6 +718,7 @@ def enable_loopback_mode(physical_port, target, laneMap):
         return -1
 
     return result
+
 
 @hook_y_cable_simulator
 def disable_loopback_mode(physical_port, target):
@@ -716,7 +731,10 @@ def disable_loopback_mode(physical_port, target):
 
     Byte offset   bits    Name                  Description
     153           7-4                           Reserved
-                  3     Lane 4 enable           "Enable loopback generation on target lane 0b1 : Enable, 0b0 disable.The cable supports 3 modes of operation : mission mode; PRBS mode or loopback mode.  Enabling loopback on any lane of any sides puts cable in loopback mode and disables PRBS.
+                  3     Lane 4 enable           "Enable loopback generation on target lane 0b1 :
+                                                 Enable, 0b0 disable.The cable supports 3 modes of operation :
+                                                 mission mode; PRBS mode or loopback mode.
+                                                 Enabling loopback on any lane of any sides puts cable in loopback mode and disables PRBS.
                   2     Lane 3 enable
                   1     Lane 2 enable
                   0     Lane 1 enable
@@ -754,6 +772,7 @@ def disable_loopback_mode(physical_port, target):
         return -1
 
     return result
+
 
 @hook_y_cable_simulator
 def get_ber_info(physical_port, target):
@@ -794,7 +813,6 @@ def get_ber_info(physical_port, target):
     if platform_chassis is not None:
         result = platform_chassis.get_sfp(
             physical_port).write_eeprom(curr_offset, 1, buffer)
-        target_wr = platform_chassis.get_sfp(physical_port).read_eeprom(curr_offset, 1)
         if result is False:
             return result
         buffer = bytearray([0])
@@ -806,7 +824,8 @@ def get_ber_info(physical_port, target):
         while(1):
             done = platform_chassis.get_sfp(physical_port).read_eeprom(curr_offset, 1)
             y_cable_validate_read_data(done, 1, physical_port, "BER data ready to read")
-            if done[0] == 1: break
+            if done[0] == 1:
+                break
 
         idx = 0
         maxLane = 2
@@ -826,6 +845,7 @@ def get_ber_info(physical_port, target):
         return -1
 
     return ber_result
+
 
 @hook_y_cable_simulator
 def get_eye_info(physical_port, target):
@@ -867,7 +887,7 @@ def get_eye_info(physical_port, target):
         if result is False:
             return result
         buffer = bytearray([0])
-        curr_offset =  Y_CABLE_INITIATE_EYE_MEASUREMENT
+        curr_offset = Y_CABLE_INITIATE_EYE_MEASUREMENT
         result = platform_chassis.get_sfp(
             physical_port).write_eeprom(curr_offset, 1, buffer)
         if result is False:
@@ -876,7 +896,8 @@ def get_eye_info(physical_port, target):
         while(1):
             done = platform_chassis.get_sfp(physical_port).read_eeprom(curr_offset, 1)
             y_cable_validate_read_data(done, 1, physical_port, "EYE data ready to read")
-            if done[0] == 1: break
+            if done[0] == 1:
+                break
 
         idx = 0
         maxLane = 2
@@ -896,4 +917,3 @@ def get_eye_info(physical_port, target):
         return -1
 
     return eye_result
-

--- a/sonic_y_cable/y_cable.py
+++ b/sonic_y_cable/y_cable.py
@@ -941,7 +941,6 @@ def get_pn_number_and_vendor_name(physical_port):
 
     curr_offset = Y_CABLE_PN_NUMBER
 
-
     if platform_chassis is not None:
         pn_result = platform_chassis.get_sfp(physical_port).read_eeprom(curr_offset, 15)
         y_cable_validate_read_data(pn_result, 1, physical_port, "PN number")
@@ -1027,9 +1026,9 @@ def get_automatic_switch_count(physical_port):
 
 
 @hook_y_cable_simulator
-def get_nic_cursor_values(physical_port, lane, target):
+def get_target_cursor_values(physical_port, lane, target):
     """
-    This API specifically returns the cursor equalization parameters for NIC.
+    This API specifically returns the cursor equalization parameters for a target(NIC, TOR1, TOR2).
     This includes pre one, pre two , main, post one, post two cursor values
 
     Args:
@@ -1056,23 +1055,23 @@ def get_nic_cursor_values(physical_port, lane, target):
 
     if platform_chassis is not None:
         pre1 = platform_chassis.get_sfp(physical_port).read_eeprom(curr_offset + (target)*20 + (lane-1)*5, 1)
-        y_cable_validate_read_data(pre1, 1, physical_port, "nic cursor result")
+        y_cable_validate_read_data(pre1, 1, physical_port, "target cursor result")
         result.append(c_int8(pre1[0]).value)
         pre2 = platform_chassis.get_sfp(physical_port).read_eeprom(curr_offset + (target)*20 + (lane-1)*5 + 1, 1)
-        y_cable_validate_read_data(pre2, 1, physical_port, "nic cursor result")
+        y_cable_validate_read_data(pre2, 1, physical_port, "target cursor result")
         result.append(c_int8(pre2[0]).value)
         main = platform_chassis.get_sfp(physical_port).read_eeprom(curr_offset + (target)*20 + (lane-1)*5 + 2, 1)
-        y_cable_validate_read_data(main, 1, physical_port, "nic cursor result")
+        y_cable_validate_read_data(main, 1, physical_port, "target cursor result")
         result.append(c_int8(main[0]).value)
         post1 = platform_chassis.get_sfp(physical_port).read_eeprom(curr_offset + (target)*20 + (lane-1)*5 + 3, 1)
-        y_cable_validate_read_data(post1, 1, physical_port, "nic cursor result")
+        y_cable_validate_read_data(post1, 1, physical_port, "target cursor result")
         result.append(c_int8(post1[0]).value)
         post2 = platform_chassis.get_sfp(physical_port).read_eeprom(curr_offset + (target)*20 + (lane-1)*5 + 4, 1)
-        y_cable_validate_read_data(post2, 1, physical_port, "nic cursor result")
+        y_cable_validate_read_data(post2, 1, physical_port, "target cursor result")
         result.append(c_int8(post2[0]).value)
 
     else:
-        helper_logger.log_error("platform_chassis is not loaded, failed to get NIC cursor values")
+        helper_logger.log_error("platform_chassis is not loaded, failed to get target cursor values")
         return -1
 
     return result

--- a/sonic_y_cable/y_cable.py
+++ b/sonic_y_cable/y_cable.py
@@ -48,6 +48,13 @@ Y_CABLE_NIC_CURSOR_VALUES = 661
 Y_CABLE_TOR1_CURSOR_VALUES = 681
 Y_CABLE_TOR2_CURSOR_VALUES = 701
 Y_CABLE_NIC_LANE_ACTIVE = 721
+Y_CABLE_COUNT_TARGET_NIC = 0
+Y_CABLE_COUNT_TARGET_TOR1 = 1
+Y_CABLE_COUNT_TARGET_TOR2 = 2
+Y_CABLE_EYE_PRBS_TARGET_LOCAL = 0
+Y_CABLE_EYE_PRBS_TARGET_TOR1 = 1
+Y_CABLE_EYE_PRBS_TARGET_TOR2 = 2
+Y_CABLE_EYE_PRBS_TARGET_NIC = 3
 
 
 SYSLOG_IDENTIFIER = "sonic_y_cable"
@@ -578,10 +585,10 @@ def enable_prbs_mode(physical_port, target, mode_value, lane_map):
              an Integer, the actual physical port connected to a Y cable
         target:
              an Integer, the target on which to enable the PRBS
-                         0 -> local side,
-                         1 -> TOR 1
-                         2 -> TOR 2
-                         3 -> NIC
+                         Y_CABLE_EYE_PRBS_TARGET_LOCAL -> local side,
+                         Y_CABLE_EYE_PRBS_TARGET_TOR1 -> TOR 1
+                         Y_CABLE_EYE_PRBS_TARGET_TOR2 -> TOR 2
+                         Y_CABLE_EYE_PRBS_TARGET_NIC -> NIC
         mode_value:
              an Integer, the mode/type for configuring the PRBS mode.
              0x00 = PRBS 9, 0x01 = PRBS 15, 0x02 = PRBS 23, 0x03 = PRBS 31
@@ -642,10 +649,10 @@ def disable_prbs_mode(physical_port, target):
              an Integer, the actual physical port connected to a Y cable
         target:
              an Integer, the target on which to enable the PRBS
-                         0 -> local side,
-                         1 -> TOR 1
-                         2 -> TOR 2
-                         3 -> NIC
+                         Y_CABLE_EYE_PRBS_TARGET_LOCAL -> local side,
+                         Y_CABLE_EYE_PRBS_TARGET_TOR1 -> TOR 1
+                         Y_CABLE_EYE_PRBS_TARGET_TOR2 -> TOR 2
+                         Y_CABLE_EYE_PRBS_TARGET_NIC -> NIC
 
     Returns:
         a boolean, true if the disable is successful
@@ -696,10 +703,10 @@ def enable_loopback_mode(physical_port, target, lane_map):
              an Integer, the actual physical port connected to a Y cable
         target:
              an Integer, the target on which to enable the PRBS
-                         0 -> local side,
-                         1 -> TOR 1
-                         2 -> TOR 2
-                         3 -> NIC
+                         Y_CABLE_EYE_PRBS_TARGET_LOCAL -> local side,
+                         Y_CABLE_EYE_PRBS_TARGET_TOR1 -> TOR 1
+                         Y_CABLE_EYE_PRBS_TARGET_TOR2 -> TOR 2
+                         Y_CABLE_EYE_PRBS_TARGET_NIC -> NIC
         lane_map:
              an Integer, representing the lane_map to be run PRBS on
              0bit for lane 0, 1bit for lane1 and so on.
@@ -754,10 +761,10 @@ def disable_loopback_mode(physical_port, target):
              an Integer, the actual physical port connected to a Y cable
         target:
              an Integer, the target on which to enable the PRBS
-                         0 -> local side,
-                         1 -> TOR 1
-                         2 -> TOR 2
-                         3 -> NIC
+                         Y_CABLE_EYE_PRBS_TARGET_LOCAL -> local side,
+                         Y_CABLE_EYE_PRBS_TARGET_TOR1 -> TOR 1
+                         Y_CABLE_EYE_PRBS_TARGET_TOR2 -> TOR 2
+                         Y_CABLE_EYE_PRBS_TARGET_NIC -> NIC
 
     Returns:
         a boolean, true if the disable is successful
@@ -807,10 +814,10 @@ def get_ber_info(physical_port, target):
              an Integer, the actual physical port connected to a Y cable
         target:
              an Integer, the target on which to enable the PRBS
-                         0 -> local side,
-                         1 -> TOR 1
-                         2 -> TOR 2
-                         3 -> NIC
+                         Y_CABLE_EYE_PRBS_TARGET_LOCAL -> local side,
+                         Y_CABLE_EYE_PRBS_TARGET_TOR1 -> TOR 1
+                         Y_CABLE_EYE_PRBS_TARGET_TOR2 -> TOR 2
+                         Y_CABLE_EYE_PRBS_TARGET_NIC -> NIC
     Returns:
         a list, with BER values of lane 0 and lane 1 with corresponding index
     """
@@ -877,10 +884,10 @@ def get_eye_info(physical_port, target):
              an Integer, the actual physical port connected to a Y cable
         target:
              an Integer, the target on which to enable the PRBS
-                         0 -> local side,
-                         1 -> TOR 1
-                         2 -> TOR 2
-                         3 -> NIC
+                         Y_CABLE_EYE_PRBS_TARGET_LOCAL -> local side,
+                         Y_CABLE_EYE_PRBS_TARGET_TOR1 -> TOR 1
+                         Y_CABLE_EYE_PRBS_TARGET_TOR2 -> TOR 2
+                         Y_CABLE_EYE_PRBS_TARGET_NIC -> NIC
     Returns:
         a list, with EYE values of lane 0 and lane 1 with corresponding index
     """
@@ -956,7 +963,7 @@ def get_pn_number_and_vendor_name(physical_port):
 
 
 @hook_y_cable_simulator
-def get_manual_switch_count(physical_port):
+def get_switch_count(physical_port, count_type):
     """
     This API specifically returns the switch count to change the Active TOR which has
     been done manually by the user.
@@ -964,58 +971,33 @@ def get_manual_switch_count(physical_port):
     Args:
         physical_port:
              an Integer, the actual physical port connected to a Y cable
+        count_type:
+             a string, for getting the count type
+                      "manual" -> manual switch count
+                      "auto" -> automatic switch count
     Returns:
         an integer, the number of times manually the Y-cable has been switched
     """
 
-    curr_offset = Y_CABLE_MANUAL_SWITCH_COUNT
-
-    count = 0
-
-    if platform_chassis is not None:
-        msb_result = platform_chassis.get_sfp(physical_port).read_eeprom(curr_offset, 1)
-        y_cable_validate_read_data(msb_result, 1, physical_port, "manual switch count msb result")
-        msb_result_1 = platform_chassis.get_sfp(physical_port).read_eeprom(curr_offset + 1, 1)
-        y_cable_validate_read_data(msb_result_1, 1, physical_port, "manual switch count msb result 1")
-        msb_result_2 = platform_chassis.get_sfp(physical_port).read_eeprom(curr_offset + 2, 1)
-        y_cable_validate_read_data(msb_result_2, 1, physical_port, "manual switch count msb result 2")
-        lsb_result = platform_chassis.get_sfp(physical_port).read_eeprom(curr_offset+3, 1)
-        y_cable_validate_read_data(lsb_result, 1, physical_port, "manual switch count lsb result")
-        count = (msb_result[0] << 24 | msb_result_1[0] << 16 | msb_result_2[0] << 8 | lsb_result[0])
-
+    if count_type == "manual":
+        curr_offset = Y_CABLE_MANUAL_SWITCH_COUNT
+    elif count_type == "auto":
+        curr_offset = Y_CABLE_AUTO_SWITCH_COUNT
     else:
-        helper_logger.log_error("platform_chassis is not loaded, failed to get manual switch count")
+        helper_logger.log_error("not a valid count_type, failed to get switch count")
         return -1
 
-    return count
-
-
-@hook_y_cable_simulator
-def get_automatic_switch_count(physical_port):
-    """
-    This API specifically returns the switch count to change the Active TOR which has
-    been done automatically by the cable.
-
-    Args:
-        physical_port:
-             an Integer, the actual physical port connected to a Y cable
-    Returns:
-        an integer, the number of times automatically  the Y-cable has been switched
-    """
-
-    curr_offset = Y_CABLE_AUTO_SWITCH_COUNT
-
     count = 0
 
     if platform_chassis is not None:
         msb_result = platform_chassis.get_sfp(physical_port).read_eeprom(curr_offset, 1)
-        y_cable_validate_read_data(msb_result, 1, physical_port, "auto switch count msb result")
+        y_cable_validate_read_data(msb_result, 1, physical_port, "{} switch count msb result".format(count_type))
         msb_result_1 = platform_chassis.get_sfp(physical_port).read_eeprom(curr_offset + 1, 1)
-        y_cable_validate_read_data(msb_result_1, 1, physical_port, "auto switch count msb result 1")
+        y_cable_validate_read_data(msb_result_1, 1, physical_port, "{} switch count msb result 1".format(count_type))
         msb_result_2 = platform_chassis.get_sfp(physical_port).read_eeprom(curr_offset + 2, 1)
-        y_cable_validate_read_data(msb_result_2, 1, physical_port, "auto switch count msb result 2")
+        y_cable_validate_read_data(msb_result_2, 1, physical_port, "{} switch count msb result 2".format(count_type))
         lsb_result = platform_chassis.get_sfp(physical_port).read_eeprom(curr_offset+3, 1)
-        y_cable_validate_read_data(lsb_result, 1, physical_port, "auto switch count lsb result")
+        y_cable_validate_read_data(lsb_result, 1, physical_port, "{} switch count lsb result".format(count_type))
         count = (msb_result[0] << 24 | msb_result_1[0] << 16 | msb_result_2[0] << 8 | lsb_result[0])
 
     else:
@@ -1042,9 +1024,9 @@ def get_target_cursor_values(physical_port, lane, target):
                          4 -> lane 4
         target:
              an Integer, the actual target to get the cursor values on
-                         0 -> NIC,
-                         1 -> TOR1,
-                         2 -> TOR2
+                         Y_CABLE_COUNT_TARGET_NIC -> NIC,
+                         Y_CABLE_COUNT_TARGET_TOR1-> TOR1,
+                         Y_CABLE_COUNT_TARGET_TOR2 -> TOR2
     Returns:
         an list, with  pre one, pre two , main, post one, post two cursor values in the order
     """

--- a/sonic_y_cable/y_cable.py
+++ b/sonic_y_cable/y_cable.py
@@ -23,38 +23,57 @@ except ImportError as e:
 # definitions of the offset with width accommodated for values
 # of MUX register specs of upper page 0x04 starting at 640
 # info eeprom for Y Cable
-Y_CABLE_IDENTFIER_LOWER_PAGE = 0
-Y_CABLE_IDENTFIER_UPPER_PAGE = 128
-Y_CABLE_DETERMINE_CABLE_READ_SIDE = 640
-Y_CABLE_CHECK_LINK_ACTIVE = 641
-Y_CABLE_SWITCH_MUX_DIRECTION = 642
-Y_CABLE_MUX_DIRECTION = 644
-Y_CABLE_ACTIVE_TOR_INDICATOR = 645
-Y_CABLE_MANUAL_SWITCH_COUNT = 669
-Y_CABLE_CONFIGURE_PRBS_TYPE = 768
-Y_CABLE_ENABLE_PRBS = 769
-Y_CABLE_INITIATE_BER_MEASUREMENT = 770
-Y_CABLE_TARGET = 794
-Y_CABLE_ENABLE_LOOPBACK = 793
-Y_CABLE_LANE_1_BER_RESULT = 771
-Y_CABLE_MAX_LANES = 2
-Y_CABLE_INITIATE_EYE_MEASUREMENT = 784
-Y_CABLE_LANE_1_EYE_RESULT = 785
-Y_CABLE_PN_NUMBER = 168
-Y_CABLE_VENDOR_NAME = 148
-Y_CABLE_MANUAL_SWITCH_COUNT = 653
-Y_CABLE_AUTO_SWITCH_COUNT = 657
-Y_CABLE_NIC_CURSOR_VALUES = 661
-Y_CABLE_TOR1_CURSOR_VALUES = 681
-Y_CABLE_TOR2_CURSOR_VALUES = 701
-Y_CABLE_NIC_LANE_ACTIVE = 721
-Y_CABLE_TARGET_NIC = 0
-Y_CABLE_TARGET_TOR1 = 1
-Y_CABLE_TARGET_TOR2 = 2
-Y_CABLE_EYE_PRBS_TARGET_LOCAL = 0
-Y_CABLE_EYE_PRBS_TARGET_TOR1 = 1
-Y_CABLE_EYE_PRBS_TARGET_TOR2 = 2
-Y_CABLE_EYE_PRBS_TARGET_NIC = 3
+OFFSET_IDENTFIER_LOWER_PAGE = 0
+OFFSET_IDENTFIER_UPPER_PAGE = 128
+OFFSET_DETERMINE_CABLE_READ_SIDE = 640
+OFFSET_CHECK_LINK_ACTIVE = 641
+OFFSET_SWITCH_MUX_DIRECTION = 642
+OFFSET_MUX_DIRECTION = 644
+OFFSET_ACTIVE_TOR_INDICATOR = 645
+OFFSET_MANUAL_SWITCH_COUNT = 669
+OFFSET_CONFIGURE_PRBS_TYPE = 768
+OFFSET_ENABLE_PRBS = 769
+OFFSET_INITIATE_BER_MEASUREMENT = 770
+OFFSET_TARGET = 794
+OFFSET_ENABLE_LOOPBACK = 793
+OFFSET_LANE_1_BER_RESULT = 771
+OFFSET_MAX_LANES = 2
+OFFSET_INITIATE_EYE_MEASUREMENT = 784
+OFFSET_LANE_1_EYE_RESULT = 785
+OFFSET_PN_NUMBER = 168
+OFFSET_VENDOR_NAME = 148
+OFFSET_MANUAL_SWITCH_COUNT = 653
+OFFSET_AUTO_SWITCH_COUNT = 657
+OFFSET_NIC_CURSOR_VALUES = 661
+OFFSET_TOR1_CURSOR_VALUES = 681
+OFFSET_TOR2_CURSOR_VALUES = 701
+OFFSET_NIC_LANE_ACTIVE = 721
+
+# definitions of targets for getting the cursor
+# equalization parameters from the register spec
+# the name of the target denotes which side cursor
+# values will be retreived
+
+TARGET_NIC = 0
+TARGET_TOR1 = 1
+TARGET_TOR2 = 2
+
+# definitions of targets for getting the EYE/BER
+# and initiating PRBS/Loopback on the Y cable
+# the name of the target denotes which side values
+# will be retreived/initiated
+
+EYE_PRBS_TARGET_LOCAL = 0
+EYE_PRBS_TARGET_TOR1 = 1
+EYE_PRBS_TARGET_TOR2 = 2
+EYE_PRBS_TARGET_NIC = 3
+
+# definitions of switch counter types
+# to be entered by the user in get_switch_count api
+# for retreiving the counter values
+
+SWITCH_COUNT_MANUAL = "manual"
+SWITCH_COUNT_AUTO = "auto"
 
 SYSLOG_IDENTIFIER = "sonic_y_cable"
 
@@ -139,7 +158,7 @@ def toggle_mux_to_torA(physical_port):
     """
 
     buffer = bytearray([2])
-    curr_offset = Y_CABLE_SWITCH_MUX_DIRECTION
+    curr_offset = OFFSET_SWITCH_MUX_DIRECTION
 
     if platform_chassis is not None:
         result = platform_chassis.get_sfp(
@@ -177,7 +196,7 @@ def toggle_mux_to_torB(physical_port):
     """
 
     buffer = bytearray([3])
-    curr_offset = Y_CABLE_SWITCH_MUX_DIRECTION
+    curr_offset = OFFSET_SWITCH_MUX_DIRECTION
 
     if platform_chassis is not None:
         result = platform_chassis.get_sfp(
@@ -215,7 +234,7 @@ def check_read_side(physical_port):
                   , -1 if reading the Y cable API fails.
     """
 
-    curr_offset = Y_CABLE_DETERMINE_CABLE_READ_SIDE
+    curr_offset = OFFSET_DETERMINE_CABLE_READ_SIDE
 
     if platform_chassis is not None:
         result = platform_chassis.get_sfp(
@@ -280,7 +299,7 @@ def check_mux_direction(physical_port):
                   , -1 if checking which side mux is pointing to API fails.
     """
 
-    curr_offset = Y_CABLE_MUX_DIRECTION
+    curr_offset = OFFSET_MUX_DIRECTION
 
     if platform_chassis is not None:
         result = platform_chassis.get_sfp(
@@ -344,7 +363,7 @@ def check_active_linked_tor_side(physical_port):
                   , -1 if checking which side linked for routing API fails.
     """
 
-    curr_offset = Y_CABLE_ACTIVE_TOR_INDICATOR
+    curr_offset = OFFSET_ACTIVE_TOR_INDICATOR
 
     if platform_chassis is not None:
         result = platform_chassis.get_sfp(
@@ -409,7 +428,7 @@ def check_if_link_is_active_for_NIC(physical_port):
         a boolean, true if the link is active
                  , false if the link is not active
     """
-    curr_offset = Y_CABLE_CHECK_LINK_ACTIVE
+    curr_offset = OFFSET_CHECK_LINK_ACTIVE
 
     if platform_chassis is not None:
         result = platform_chassis.get_sfp(
@@ -465,7 +484,7 @@ def check_if_link_is_active_for_torA(physical_port):
                  , false if the link is not active
     """
 
-    curr_offset = Y_CABLE_CHECK_LINK_ACTIVE
+    curr_offset = OFFSET_CHECK_LINK_ACTIVE
 
     if platform_chassis is not None:
         result = platform_chassis.get_sfp(
@@ -521,7 +540,7 @@ def check_if_link_is_active_for_torB(physical_port):
                  , false if the link is not active
     """
 
-    curr_offset = Y_CABLE_CHECK_LINK_ACTIVE
+    curr_offset = OFFSET_CHECK_LINK_ACTIVE
 
     if platform_chassis is not None:
         result = platform_chassis.get_sfp(
@@ -584,10 +603,10 @@ def enable_prbs_mode(physical_port, target, mode_value, lane_map):
              an Integer, the actual physical port connected to a Y cable
         target:
              an Integer, the target on which to enable the PRBS
-                         Y_CABLE_EYE_PRBS_TARGET_LOCAL -> local side,
-                         Y_CABLE_EYE_PRBS_TARGET_TOR1 -> TOR 1
-                         Y_CABLE_EYE_PRBS_TARGET_TOR2 -> TOR 2
-                         Y_CABLE_EYE_PRBS_TARGET_NIC -> NIC
+                         EYE_PRBS_TARGET_LOCAL -> local side,
+                         EYE_PRBS_TARGET_TOR1 -> TOR 1
+                         EYE_PRBS_TARGET_TOR2 -> TOR 2
+                         EYE_PRBS_TARGET_NIC -> NIC
         mode_value:
              an Integer, the mode/type for configuring the PRBS mode.
              0x00 = PRBS 9, 0x01 = PRBS 15, 0x02 = PRBS 23, 0x03 = PRBS 31
@@ -602,7 +621,7 @@ def enable_prbs_mode(physical_port, target, mode_value, lane_map):
     """
 
     buffer = bytearray([target])
-    curr_offset = Y_CABLE_TARGET
+    curr_offset = OFFSET_TARGET
 
     if platform_chassis is not None:
         result = platform_chassis.get_sfp(
@@ -610,13 +629,13 @@ def enable_prbs_mode(physical_port, target, mode_value, lane_map):
         if result is False:
             return result
         buffer = bytearray([mode_value])
-        curr_offset = Y_CABLE_CONFIGURE_PRBS_TYPE
+        curr_offset = OFFSET_CONFIGURE_PRBS_TYPE
         result = platform_chassis.get_sfp(
             physical_port).write_eeprom(curr_offset, 1, buffer)
         if result is False:
             return result
         buffer = bytearray([lane_map])
-        curr_offset = Y_CABLE_ENABLE_PRBS
+        curr_offset = OFFSET_ENABLE_PRBS
         result = platform_chassis.get_sfp(
             physical_port).write_eeprom(curr_offset, 1, buffer)
 
@@ -648,10 +667,10 @@ def disable_prbs_mode(physical_port, target):
              an Integer, the actual physical port connected to a Y cable
         target:
              an Integer, the target on which to enable the PRBS
-                         Y_CABLE_EYE_PRBS_TARGET_LOCAL -> local side,
-                         Y_CABLE_EYE_PRBS_TARGET_TOR1 -> TOR 1
-                         Y_CABLE_EYE_PRBS_TARGET_TOR2 -> TOR 2
-                         Y_CABLE_EYE_PRBS_TARGET_NIC -> NIC
+                         EYE_PRBS_TARGET_LOCAL -> local side,
+                         EYE_PRBS_TARGET_TOR1 -> TOR 1
+                         EYE_PRBS_TARGET_TOR2 -> TOR 2
+                         EYE_PRBS_TARGET_NIC -> NIC
 
     Returns:
         a boolean, true if the disable is successful
@@ -659,7 +678,7 @@ def disable_prbs_mode(physical_port, target):
     """
 
     buffer = bytearray([target])
-    curr_offset = Y_CABLE_TARGET
+    curr_offset = OFFSET_TARGET
 
     if platform_chassis is not None:
         result = platform_chassis.get_sfp(
@@ -667,7 +686,7 @@ def disable_prbs_mode(physical_port, target):
         if result is False:
             return result
         buffer = bytearray([0])
-        curr_offset = Y_CABLE_ENABLE_PRBS
+        curr_offset = OFFSET_ENABLE_PRBS
         result = platform_chassis.get_sfp(
             physical_port).write_eeprom(curr_offset, 1, buffer)
 
@@ -702,10 +721,10 @@ def enable_loopback_mode(physical_port, target, lane_map):
              an Integer, the actual physical port connected to a Y cable
         target:
              an Integer, the target on which to enable the PRBS
-                         Y_CABLE_EYE_PRBS_TARGET_LOCAL -> local side,
-                         Y_CABLE_EYE_PRBS_TARGET_TOR1 -> TOR 1
-                         Y_CABLE_EYE_PRBS_TARGET_TOR2 -> TOR 2
-                         Y_CABLE_EYE_PRBS_TARGET_NIC -> NIC
+                         EYE_PRBS_TARGET_LOCAL -> local side,
+                         EYE_PRBS_TARGET_TOR1 -> TOR 1
+                         EYE_PRBS_TARGET_TOR2 -> TOR 2
+                         EYE_PRBS_TARGET_NIC -> NIC
         lane_map:
              an Integer, representing the lane_map to be run PRBS on
              0bit for lane 0, 1bit for lane1 and so on.
@@ -717,7 +736,7 @@ def enable_loopback_mode(physical_port, target, lane_map):
     """
 
     buffer = bytearray([target])
-    curr_offset = Y_CABLE_TARGET
+    curr_offset = OFFSET_TARGET
 
     if platform_chassis is not None:
         result = platform_chassis.get_sfp(
@@ -725,7 +744,7 @@ def enable_loopback_mode(physical_port, target, lane_map):
         if result is False:
             return result
         buffer = bytearray([lane_map])
-        curr_offset = Y_CABLE_ENABLE_LOOPBACK
+        curr_offset = OFFSET_ENABLE_LOOPBACK
         result = platform_chassis.get_sfp(
             physical_port).write_eeprom(curr_offset, 1, buffer)
 
@@ -760,10 +779,10 @@ def disable_loopback_mode(physical_port, target):
              an Integer, the actual physical port connected to a Y cable
         target:
              an Integer, the target on which to enable the PRBS
-                         Y_CABLE_EYE_PRBS_TARGET_LOCAL -> local side,
-                         Y_CABLE_EYE_PRBS_TARGET_TOR1 -> TOR 1
-                         Y_CABLE_EYE_PRBS_TARGET_TOR2 -> TOR 2
-                         Y_CABLE_EYE_PRBS_TARGET_NIC -> NIC
+                         EYE_PRBS_TARGET_LOCAL -> local side,
+                         EYE_PRBS_TARGET_TOR1 -> TOR 1
+                         EYE_PRBS_TARGET_TOR2 -> TOR 2
+                         EYE_PRBS_TARGET_NIC -> NIC
 
     Returns:
         a boolean, true if the disable is successful
@@ -771,7 +790,7 @@ def disable_loopback_mode(physical_port, target):
     """
 
     buffer = bytearray([target])
-    curr_offset = Y_CABLE_TARGET
+    curr_offset = OFFSET_TARGET
 
     if platform_chassis is not None:
         result = platform_chassis.get_sfp(
@@ -779,7 +798,7 @@ def disable_loopback_mode(physical_port, target):
         if result is False:
             return result
         buffer = bytearray([0])
-        curr_offset = Y_CABLE_ENABLE_LOOPBACK
+        curr_offset = OFFSET_ENABLE_LOOPBACK
         result = platform_chassis.get_sfp(
             physical_port).write_eeprom(curr_offset, 1, buffer)
 
@@ -813,16 +832,16 @@ def get_ber_info(physical_port, target):
              an Integer, the actual physical port connected to a Y cable
         target:
              an Integer, the target on which to enable the PRBS
-                         Y_CABLE_EYE_PRBS_TARGET_LOCAL -> local side,
-                         Y_CABLE_EYE_PRBS_TARGET_TOR1 -> TOR 1
-                         Y_CABLE_EYE_PRBS_TARGET_TOR2 -> TOR 2
-                         Y_CABLE_EYE_PRBS_TARGET_NIC -> NIC
+                         EYE_PRBS_TARGET_LOCAL -> local side,
+                         EYE_PRBS_TARGET_TOR1 -> TOR 1
+                         EYE_PRBS_TARGET_TOR2 -> TOR 2
+                         EYE_PRBS_TARGET_NIC -> NIC
     Returns:
         a list, with BER values of lane 0 and lane 1 with corresponding index
     """
 
     buffer = bytearray([target])
-    curr_offset = Y_CABLE_TARGET
+    curr_offset = OFFSET_TARGET
 
     ber_result = []
 
@@ -832,7 +851,7 @@ def get_ber_info(physical_port, target):
         if result is False:
             return result
         buffer = bytearray([0])
-        curr_offset = Y_CABLE_INITIATE_BER_MEASUREMENT
+        curr_offset = OFFSET_INITIATE_BER_MEASUREMENT
         result = platform_chassis.get_sfp(
             physical_port).write_eeprom(curr_offset, 1, buffer)
         if result is False:
@@ -845,7 +864,7 @@ def get_ber_info(physical_port, target):
 
         idx = 0
         maxLane = 2
-        curr_offset = Y_CABLE_LANE_1_BER_RESULT
+        curr_offset = OFFSET_LANE_1_BER_RESULT
         for lane in range(maxLane):
             msb_result = platform_chassis.get_sfp(physical_port).read_eeprom(curr_offset+idx, 1)
             y_cable_validate_read_data(msb_result, 1, physical_port, "BER data msb result")
@@ -883,16 +902,16 @@ def get_eye_info(physical_port, target):
              an Integer, the actual physical port connected to a Y cable
         target:
              an Integer, the target on which to enable the PRBS
-                         Y_CABLE_EYE_PRBS_TARGET_LOCAL -> local side,
-                         Y_CABLE_EYE_PRBS_TARGET_TOR1 -> TOR 1
-                         Y_CABLE_EYE_PRBS_TARGET_TOR2 -> TOR 2
-                         Y_CABLE_EYE_PRBS_TARGET_NIC -> NIC
+                         EYE_PRBS_TARGET_LOCAL -> local side,
+                         EYE_PRBS_TARGET_TOR1 -> TOR 1
+                         EYE_PRBS_TARGET_TOR2 -> TOR 2
+                         EYE_PRBS_TARGET_NIC -> NIC
     Returns:
         a list, with EYE values of lane 0 and lane 1 with corresponding index
     """
 
     buffer = bytearray([target])
-    curr_offset = Y_CABLE_TARGET
+    curr_offset = OFFSET_TARGET
 
     eye_result = []
 
@@ -902,7 +921,7 @@ def get_eye_info(physical_port, target):
         if result is False:
             return result
         buffer = bytearray([0])
-        curr_offset = Y_CABLE_INITIATE_EYE_MEASUREMENT
+        curr_offset = OFFSET_INITIATE_EYE_MEASUREMENT
         result = platform_chassis.get_sfp(
             physical_port).write_eeprom(curr_offset, 1, buffer)
         if result is False:
@@ -917,7 +936,7 @@ def get_eye_info(physical_port, target):
         idx = 0
         maxLane = 2
         for lane in range(maxLane):
-            curr_offset = Y_CABLE_LANE_1_EYE_RESULT
+            curr_offset = OFFSET_LANE_1_EYE_RESULT
             msb_result = platform_chassis.get_sfp(physical_port).read_eeprom(curr_offset+idx, 1)
             y_cable_validate_read_data(msb_result, 1, physical_port, "EYE data msb result")
             lsb_result = platform_chassis.get_sfp(physical_port).read_eeprom(curr_offset+1+idx, 1)
@@ -945,12 +964,12 @@ def get_pn_number_and_vendor_name(physical_port):
         a tuple, with pn_number and vendor name
     """
 
-    curr_offset = Y_CABLE_PN_NUMBER
+    curr_offset = OFFSET_PN_NUMBER
 
     if platform_chassis is not None:
         pn_result = platform_chassis.get_sfp(physical_port).read_eeprom(curr_offset, 15)
         y_cable_validate_read_data(pn_result, 1, physical_port, "PN number")
-        curr_offset = Y_CABLE_VENDOR_NAME
+        curr_offset = OFFSET_VENDOR_NAME
         vendor_name = platform_chassis.get_sfp(physical_port).read_eeprom(curr_offset, 15)
         y_cable_validate_read_data(vendor_name, 15, physical_port, "vendor name")
 
@@ -978,10 +997,10 @@ def get_switch_count(physical_port, count_type):
         an integer, the number of times manually the Y-cable has been switched
     """
 
-    if count_type == "manual":
-        curr_offset = Y_CABLE_MANUAL_SWITCH_COUNT
-    elif count_type == "auto":
-        curr_offset = Y_CABLE_AUTO_SWITCH_COUNT
+    if count_type == SWITCH_COUNT_MANUAL:
+        curr_offset = OFFSET_MANUAL_SWITCH_COUNT
+    elif count_type == SWITCH_COUNT_AUTO:
+        curr_offset = OFFSET_AUTO_SWITCH_COUNT
     else:
         helper_logger.log_error("not a valid count_type, failed to get switch count")
         return -1
@@ -1023,14 +1042,14 @@ def get_target_cursor_values(physical_port, lane, target):
                          4 -> lane 4
         target:
              an Integer, the actual target to get the cursor values on
-                         Y_CABLE_TARGET_NIC -> NIC,
-                         Y_CABLE_TARGET_TOR1-> TOR1,
-                         Y_CABLE_TARGET_TOR2 -> TOR2
+                         TARGET_NIC -> NIC,
+                         TARGET_TOR1-> TOR1,
+                         TARGET_TOR2 -> TOR2
     Returns:
         an list, with  pre one, pre two , main, post one, post two cursor values in the order
     """
 
-    curr_offset = Y_CABLE_NIC_CURSOR_VALUES
+    curr_offset = OFFSET_NIC_CURSOR_VALUES
 
     result = []
 
@@ -1072,7 +1091,7 @@ def check_if_nic_lanes_active(physical_port):
              in that order.
     """
 
-    curr_offset = Y_CABLE_NIC_LANE_ACTIVE
+    curr_offset = OFFSET_NIC_LANE_ACTIVE
 
     result = None
 


### PR DESCRIPTION
Summary:
This PR provides the necessary infrastructure to add support for measuring BER (Bit error rate) and Eye scan and also 
run different modes on the Cable - PRBS and Loopback. 
### Type of change

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
Added changes in the sonic_y_cable package

#### What is the motivation for this PR?
To add the necessary support for measuring BER and EYE scan, and run PRBS/Loopback modes on the Y cable 

#### How did you do it?
Added the changes in sonic-platform-common module in the y_cable.py file

#### How did you verify/test it?
opened a python shell and ran the API's manually and test verified
the values are correct.

Signed-off-by: vaibhav-dahiya <vdahiya@microsoft.com>