### PR TITLE
[sffbase] Make convert_hex_to_string() compatible with both Python 2 and Python 3

### DIFF
--- a/sonic_platform_base/sonic_sfp/sffbase.py
+++ b/sonic_platform_base/sonic_sfp/sffbase.py
@@ -35,7 +35,7 @@ class sffbase(object):
             ret_str = ''
             for n in range(start, end):
                 ret_str += arr[n]
-            return str.strip(binascii.unhexlify(ret_str))
+            return binascii.unhexlify(ret_str).decode("utf-8").strip()
         except Exception as err:
             return str(err)
 


### PR DESCRIPTION
When called with Python 3, `str.strip(binascii.unhexlify(ret_str))` will raise an exception: ` descriptor 'strip' requires a 'str' object but received a 'bytes'`. This patch (`binascii.unhexlify(ret_str).decode("utf-8").strip()`) will work properly with both Python 2 and Python 3.

Fixes https://github.com/Azure/sonic-platform-common/issues/160