### PR TITLE
[sonic_y_cable] add stub function for upgrade firmware of Y cable and split the get_part_number and get_vendor API's

### DIFF
--- a/sonic_y_cable/y_cable.py
+++ b/sonic_y_cable/y_cable.py
@@ -1282,10 +1282,10 @@ def get_local_voltage(physical_port):
     if platform_chassis is not None:
         curr_offset = OFFSET_INTERNAL_VOLTAGE
         msb_result = platform_chassis.get_sfp(physical_port).read_eeprom(curr_offset, 1)
-        if y_cable_validate_read_data(msb_result, 1, physical_port, "local voltage msb") == EEPROM_READ_DATA_INVALID:
+        if y_cable_validate_read_data(msb_result, 1, physical_port, "local voltage MSB") == EEPROM_READ_DATA_INVALID:
             return EEPROM_ERROR
         lsb_result = platform_chassis.get_sfp(physical_port).read_eeprom(curr_offset+1, 1)
-        if y_cable_validate_read_data(lsb_result, 1, physical_port, "local voltage lsb") == EEPROM_READ_DATA_INVALID:
+        if y_cable_validate_read_data(lsb_result, 1, physical_port, "local voltage LSB") == EEPROM_READ_DATA_INVALID:
             return EEPROM_ERROR
 
         voltage = (((msb_result[0] << 8) | lsb_result[0]) * 0.0001)
@@ -1300,7 +1300,7 @@ def get_nic_temperature(physical_port):
     curr_offset = OFFSET_NIC_TEMPERATURE
     if platform_chassis is not None:
         result = platform_chassis.get_sfp(physical_port).read_eeprom(curr_offset, 1)
-        if y_cable_validate_read_data(result, 1, physical_port, "internal voltage") == EEPROM_READ_DATA_INVALID:
+        if y_cable_validate_read_data(result, 1, physical_port, "NIC temperature") == EEPROM_READ_DATA_INVALID:
             return EEPROM_ERROR
         temp = result[0]
     else:
@@ -1314,10 +1314,10 @@ def get_nic_voltage(physical_port):
     curr_offset = OFFSET_NIC_VOLTAGE
     if platform_chassis is not None:
         msb_result = platform_chassis.get_sfp(physical_port).read_eeprom(curr_offset, 1)
-        if y_cable_validate_read_data(msb_result, 1, physical_port, "nic voltage msb") == EEPROM_READ_DATA_INVALID:
+        if y_cable_validate_read_data(msb_result, 1, physical_port, "NIC voltage MSB") == EEPROM_READ_DATA_INVALID:
             return EEPROM_ERROR
         lsb_result = platform_chassis.get_sfp(physical_port).read_eeprom(curr_offset+1, 1)
-        if y_cable_validate_read_data(lsb_result, 1, physical_port, "nic voltage lsb") == EEPROM_READ_DATA_INVALID:
+        if y_cable_validate_read_data(lsb_result, 1, physical_port, "NIC voltage LSB") == EEPROM_READ_DATA_INVALID:
             return EEPROM_ERROR
 
         voltage = (((msb_result[0] << 8) | lsb_result[0]) * 0.0001)

--- a/sonic_y_cable/y_cable.py
+++ b/sonic_y_cable/y_cable.py
@@ -41,7 +41,7 @@ OFFSET_LANE_1_BER_RESULT = 771
 OFFSET_MAX_LANES = 2
 OFFSET_INITIATE_EYE_MEASUREMENT = 784
 OFFSET_LANE_1_EYE_RESULT = 785
-OFFSET_PN_NUMBER = 168
+OFFSET_PART_NUMBER = 168
 OFFSET_VENDOR_NAME = 148
 OFFSET_MANUAL_SWITCH_COUNT = 653
 OFFSET_AUTO_SWITCH_COUNT = 657
@@ -992,17 +992,17 @@ def get_part_number(physical_port):
         a string, with part number
     """
 
-    curr_offset = OFFSET_PN_NUMBER
+    curr_offset = OFFSET_PART_NUMBER
 
     if platform_chassis is not None:
-        pn_result = platform_chassis.get_sfp(physical_port).read_eeprom(curr_offset, 15)
-        if y_cable_validate_read_data(pn_result, 15, physical_port, "PN number") == EEPROM_READ_DATA_INVALID:
+        part_result = platform_chassis.get_sfp(physical_port).read_eeprom(curr_offset, 15)
+        if y_cable_validate_read_data(part_result, 15, physical_port, "Part number") == EEPROM_READ_DATA_INVALID:
             return EEPROM_ERROR
     else:
         helper_logger.log_error("platform_chassis is not loaded, failed to get part number")
         return -1
 
-    part_number = str(pn_result.decode())
+    part_number = str(part_result.decode())
 
     return part_number
 
@@ -1021,7 +1021,7 @@ def get_vendor(physical_port):
 
     if platform_chassis is not None:
         result = platform_chassis.get_sfp(physical_port).read_eeprom(curr_offset, 15)
-        if y_cable_validate_read_data(result, 15, physical_port, "PN number") == EEPROM_READ_DATA_INVALID:
+        if y_cable_validate_read_data(result, 15, physical_port, "Part number") == EEPROM_READ_DATA_INVALID:
             return EEPROM_ERROR
     else:
         helper_logger.log_error("platform_chassis is not loaded, failed to get vendor")
@@ -1263,34 +1263,34 @@ def get_nic_voltage_temp(physical_port):
 
     return temp, voltage
 
-def get_internal_temperature(physical_port):
+def get_local_temperature(physical_port):
 
     curr_offset = OFFSET_INTERNAL_TEMPERATURE
     if platform_chassis is not None:
         result = platform_chassis.get_sfp(physical_port).read_eeprom(curr_offset, 1)
-        if y_cable_validate_read_data(result, 1, physical_port, "internal temperature") == EEPROM_READ_DATA_INVALID:
+        if y_cable_validate_read_data(result, 1, physical_port, "local temperature") == EEPROM_READ_DATA_INVALID:
             return EEPROM_ERROR
         temp = result[0]
     else:
-        helper_logger.log_error("platform_chassis is not loaded, failed to get internal temp")
+        helper_logger.log_error("platform_chassis is not loaded, failed to get local temp")
         return -1
 
     return temp
 
-def get_internal_voltage(physical_port):
+def get_local_voltage(physical_port):
 
     if platform_chassis is not None:
         curr_offset = OFFSET_INTERNAL_VOLTAGE
         msb_result = platform_chassis.get_sfp(physical_port).read_eeprom(curr_offset, 1)
-        if y_cable_validate_read_data(msb_result, 1, physical_port, "internal voltage msb") == EEPROM_READ_DATA_INVALID:
+        if y_cable_validate_read_data(msb_result, 1, physical_port, "local voltage msb") == EEPROM_READ_DATA_INVALID:
             return EEPROM_ERROR
         lsb_result = platform_chassis.get_sfp(physical_port).read_eeprom(curr_offset+1, 1)
-        if y_cable_validate_read_data(lsb_result, 1, physical_port, "internal voltage lsb") == EEPROM_READ_DATA_INVALID:
+        if y_cable_validate_read_data(lsb_result, 1, physical_port, "local voltage lsb") == EEPROM_READ_DATA_INVALID:
             return EEPROM_ERROR
 
         voltage = (((msb_result[0] << 8) | lsb_result[0]) * 0.0001)
     else:
-        helper_logger.log_error("platform_chassis is not loaded, failed to get internal voltage")
+        helper_logger.log_error("platform_chassis is not loaded, failed to get local voltage")
         return -1
 
     return voltage

--- a/sonic_y_cable/y_cable.py
+++ b/sonic_y_cable/y_cable.py
@@ -1006,6 +1006,7 @@ def get_part_number(physical_port):
 
     return part_number
 
+
 def get_vendor(physical_port):
     """
     This API specifically returns the vendor name of the Y cable for a specfic port.
@@ -1030,6 +1031,7 @@ def get_vendor(physical_port):
     vendor_name = str(result.decode())
 
     return vendor_name
+
 
 def get_switch_count(physical_port, count_type):
     """
@@ -1263,6 +1265,7 @@ def get_nic_voltage_temp(physical_port):
 
     return temp, voltage
 
+
 def get_local_temperature(physical_port):
 
     curr_offset = OFFSET_INTERNAL_TEMPERATURE
@@ -1276,6 +1279,7 @@ def get_local_temperature(physical_port):
         return -1
 
     return temp
+
 
 def get_local_voltage(physical_port):
 
@@ -1295,6 +1299,7 @@ def get_local_voltage(physical_port):
 
     return voltage
 
+
 def get_nic_temperature(physical_port):
 
     curr_offset = OFFSET_NIC_TEMPERATURE
@@ -1308,6 +1313,7 @@ def get_nic_temperature(physical_port):
         return -1
 
     return temp
+
 
 def get_nic_voltage(physical_port):
 
@@ -1327,8 +1333,8 @@ def get_nic_voltage(physical_port):
 
     return voltage
 
-def upgrade_firmware(physical_port, fwfile):
 
+def upgrade_firmware(physical_port, fwfile):
     """ This routine should facilitate complete firmware
     upgrade of the Y cable on all the three ends of the
     Y cable of the port specified.
@@ -1348,4 +1354,4 @@ def upgrade_firmware(physical_port, fwfile):
              or an error code as to what was the cause of firmware upgrade failure
     """
 
-    return FIRMWARE_UPGRADE_SUCCESS 
+    return FIRMWARE_UPGRADE_SUCCESS

--- a/sonic_y_cable/y_cable.py
+++ b/sonic_y_cable/y_cable.py
@@ -999,7 +999,7 @@ def get_part_number(physical_port):
         if y_cable_validate_read_data(pn_result, 15, physical_port, "PN number") == EEPROM_READ_DATA_INVALID:
             return EEPROM_ERROR
     else:
-        helper_logger.log_error("platform_chassis is not loaded, failed to get pin results")
+        helper_logger.log_error("platform_chassis is not loaded, failed to get part number")
         return -1
 
     part_number = str(pn_result.decode())
@@ -1024,7 +1024,7 @@ def get_vendor(physical_port):
         if y_cable_validate_read_data(result, 15, physical_port, "PN number") == EEPROM_READ_DATA_INVALID:
             return EEPROM_ERROR
     else:
-        helper_logger.log_error("platform_chassis is not loaded, failed to get pin results")
+        helper_logger.log_error("platform_chassis is not loaded, failed to get vendor")
         return -1
 
     vendor_name = str(result.decode())
@@ -1262,6 +1262,70 @@ def get_nic_voltage_temp(physical_port):
         return -1
 
     return temp, voltage
+
+def get_internal_temperature(physical_port):
+
+    curr_offset = OFFSET_INTERNAL_TEMPERATURE
+    if platform_chassis is not None:
+        result = platform_chassis.get_sfp(physical_port).read_eeprom(curr_offset, 1)
+        if y_cable_validate_read_data(result, 1, physical_port, "internal temperature") == EEPROM_READ_DATA_INVALID:
+            return EEPROM_ERROR
+        temp = result[0]
+    else:
+        helper_logger.log_error("platform_chassis is not loaded, failed to get internal temp")
+        return -1
+
+    return temp
+
+def get_internal_voltage(physical_port):
+
+    if platform_chassis is not None:
+        curr_offset = OFFSET_INTERNAL_VOLTAGE
+        msb_result = platform_chassis.get_sfp(physical_port).read_eeprom(curr_offset, 1)
+        if y_cable_validate_read_data(msb_result, 1, physical_port, "internal voltage msb") == EEPROM_READ_DATA_INVALID:
+            return EEPROM_ERROR
+        lsb_result = platform_chassis.get_sfp(physical_port).read_eeprom(curr_offset+1, 1)
+        if y_cable_validate_read_data(lsb_result, 1, physical_port, "internal voltage lsb") == EEPROM_READ_DATA_INVALID:
+            return EEPROM_ERROR
+
+        voltage = (((msb_result[0] << 8) | lsb_result[0]) * 0.0001)
+    else:
+        helper_logger.log_error("platform_chassis is not loaded, failed to get internal voltage")
+        return -1
+
+    return voltage
+
+def get_nic_temperature(physical_port):
+
+    curr_offset = OFFSET_NIC_TEMPERATURE
+    if platform_chassis is not None:
+        result = platform_chassis.get_sfp(physical_port).read_eeprom(curr_offset, 1)
+        if y_cable_validate_read_data(result, 1, physical_port, "internal voltage") == EEPROM_READ_DATA_INVALID:
+            return EEPROM_ERROR
+        temp = result[0]
+    else:
+        helper_logger.log_error("platform_chassis is not loaded, failed to get NIC temp")
+        return -1
+
+    return temp
+
+def get_nic_voltage(physical_port):
+
+    curr_offset = OFFSET_NIC_VOLTAGE
+    if platform_chassis is not None:
+        msb_result = platform_chassis.get_sfp(physical_port).read_eeprom(curr_offset, 1)
+        if y_cable_validate_read_data(msb_result, 1, physical_port, "nic voltage msb") == EEPROM_READ_DATA_INVALID:
+            return EEPROM_ERROR
+        lsb_result = platform_chassis.get_sfp(physical_port).read_eeprom(curr_offset+1, 1)
+        if y_cable_validate_read_data(lsb_result, 1, physical_port, "nic voltage lsb") == EEPROM_READ_DATA_INVALID:
+            return EEPROM_ERROR
+
+        voltage = (((msb_result[0] << 8) | lsb_result[0]) * 0.0001)
+    else:
+        helper_logger.log_error("platform_chassis is not loaded, failed to get NIC voltage")
+        return -1
+
+    return voltage
 
 def upgrade_firmware(physical_port, fwfile):
 

--- a/sonic_y_cable/y_cable.py
+++ b/sonic_y_cable/y_cable.py
@@ -1022,10 +1022,10 @@ def get_vendor(physical_port):
 
     if platform_chassis is not None:
         result = platform_chassis.get_sfp(physical_port).read_eeprom(curr_offset, 15)
-        if y_cable_validate_read_data(result, 15, physical_port, "Part number") == EEPROM_READ_DATA_INVALID:
+        if y_cable_validate_read_data(result, 15, physical_port, "Vendor name") == EEPROM_READ_DATA_INVALID:
             return EEPROM_ERROR
     else:
-        helper_logger.log_error("platform_chassis is not loaded, failed to get vendor")
+        helper_logger.log_error("platform_chassis is not loaded, failed to get Vendor name")
         return -1
 
     vendor_name = str(result.decode())

--- a/sonic_y_cable/y_cable.py
+++ b/sonic_y_cable/y_cable.py
@@ -1237,3 +1237,36 @@ def get_nic_voltage_temp(physical_port):
         return -1
 
     return temp, voltage
+
+def firmware_upgrade(physical_port, fwfile):
+
+    """ This routine should facilitate complete firmware
+    upgrade of the Y cable on all the three ends of the Y cable.
+    All the componenets of the Y cable should be upgraded
+    in their entirety by this single call subroutine.
+    This should return True on success and an error code otherwise.
+    If an error occurs during firmware upgrade this function,
+    should not attempt to do a rollback to the original version but
+    rather just return an error code stating the cause of failure as applicable.
+    Note that the error code on failure should reflect whether a rollback
+    or synchronization is required or not after calling this routine.
+    Meaning for example if one of the ends of the Y cable could not complete the upgrade
+    and the cable could require synchronization after this subroutine call,
+    then an error code to stating that should be the return value. Likewise if all the links are down
+    then that would not require a rollback of any sort and hence the error code should just reflect that.
+    Hence after calling this subroutine the caller can then determine
+    whether further action is necessary for firmware upgrade or not.
+
+    Args:
+        physical_port:
+             an Integer, the actual physical port connected to a Y cable
+        fwfile:
+             a File, the actual binary or executable which contains the firmware
+    Returns:
+        an Boolean:
+             True on sucessful firmware upgrade
+        an Integer:
+             an error code stating what was the cause of firmware upgrade failure
+    """
+
+    return True

--- a/sonic_y_cable/y_cable.py
+++ b/sonic_y_cable/y_cable.py
@@ -92,6 +92,12 @@ EYE_TIMEOUT_SECS = 1
 
 MAX_NUM_LANES = 4
 
+# definitions of firmware upgrade codes
+# to be returned by the user when calling the
+# firmware upgrade routine
+FIRMWARE_UPGRADE_SUCCESS = 0
+FIRMWARE_UPGRADE_FAILURE = 1
+
 SYSLOG_IDENTIFIER = "sonic_y_cable"
 
 # Global logger instance for helper functions and classes to log
@@ -1241,19 +1247,21 @@ def get_nic_voltage_temp(physical_port):
 def firmware_upgrade(physical_port, fwfile):
 
     """ This routine should facilitate complete firmware
-    upgrade of the Y cable on all the three ends of the Y cable.
-    All the componenets of the Y cable should be upgraded
+    upgrade of the Y cable on all the three ends of the
+    Y cable of the port specified.
+    All the components of the Y cable should be upgraded and committed
     in their entirety by this single call subroutine.
-    This should return True on success and an error code otherwise.
-    If an error occurs during firmware upgrade this function,
-    should not attempt to do a rollback to the original version but
-    rather just return an error code stating the cause of failure as applicable.
+    This should return success code if firmware upgrade is successfull
+    and an error code otherwise.
     Note that the error code on failure should reflect whether a rollback
-    or synchronization is required or not after calling this routine.
-    Meaning for example if one of the ends of the Y cable could not complete the upgrade
-    and the cable could require synchronization after this subroutine call,
-    then an error code to stating that should be the return value. Likewise if all the links are down
-    then that would not require a rollback of any sort and hence the error code should just reflect that.
+    or synchronization would be required or not required after calling this
+    routine.
+    Meaning for example if one of the ends of the Y cable could not
+    complete the upgrade and the cable could then require synchronization
+    after this subroutine call, then an error code stating that should
+    be the return value. Likewise if all the links are down
+    then that would not require a rollback of any sort and hence the error code 
+    should just reflect that.
     Hence after calling this subroutine the caller can then determine
     whether further action is necessary for firmware upgrade or not.
 
@@ -1263,10 +1271,9 @@ def firmware_upgrade(physical_port, fwfile):
         fwfile:
              a File, the actual binary or executable which contains the firmware
     Returns:
-        an Boolean:
-             True on sucessful firmware upgrade
         an Integer:
-             an error code stating what was the cause of firmware upgrade failure
+             a predefined code stating whether the firmware upgrade was successful
+             or an error code as to what was the cause of firmware upgrade failure
     """
 
-    return True
+    return FIRMWARE_UPGRADE_SUCCESS 


### PR DESCRIPTION

<!-- Provide a general summary of your changes in the Title above -->
This PR adds a stub function definition with details as to how it should be implemented by a Y cable vendor. 

#### Description
Added a stub function definition with a doc string describing how it should be implemented
Cleaning up and split some API's for vendors
<!--
     Describe your changes in detail
-->

#### Motivation and Context

Firmware upgrade is a functionality that vendors need to implement, this PR adds the definition 
and a description of how the implementation of this firmware_upgrade  API should be 
<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->

#### How Has This Been Tested?
Will be tested once implemented
for cleanup API's opened a python shell and executed API's for correctness
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->

#### Additional Information (Optional)

Signed-off-by: vaibhav-dahiya <vdahiya@microsoft.com>