### PR TITLE
[y_cable] add support for enable/disable autoswitch feature on Y cable

### DIFF
--- a/sonic_y_cable/y_cable.py
+++ b/sonic_y_cable/y_cable.py
@@ -92,9 +92,9 @@ EYE_TIMEOUT_SECS = 1
 
 MAX_NUM_LANES = 4
 
-# definitions for switching modes inside muxcable
-SWITCHING_MODE_AUTO = 1
+# switching modes inside muxcable
 SWITCHING_MODE_MANUAL = 0
+SWITCHING_MODE_AUTO = 1
 
 # Valid return codes for upgrade firmware routine steps
 FIRMWARE_DOWNLOAD_SUCCESS = 0


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
This PR adds functions definition with details for enabling/disabling Y cable auto-switch feature

#### Description
Added functions for enabling/disabling auto-switch on Y cable
```
def set_switching_mode(physical_port, mode)
def get_switching_mode(physical_port)
```

<!--
     Describe your changes in detail
-->

#### Motivation and Context

We need to have this feature within host cli so that a user can enable/disable the autoswitch on Y cable
<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->

#### How Has This Been Tested?
opened a python shell and executed API's for correctness
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->






#### Additional Information (Optional)

Signed-off-by: vaibhav-dahiya <vdahiya@microsoft.com>