### PR TITLE
Change import order in Ycable helper and EEPROM read bytearray change in SFP plugin

### DIFF
--- a/sonic_platform_base/sonic_sfp/sfputilbase.py
+++ b/sonic_platform_base/sonic_sfp/sfputilbase.py
@@ -344,16 +344,10 @@ class SfpUtilBase(object):
             return None
 
         try:
-            # in case raw is bytes (python3 is used) raw[n] will return int,
-            # and in case raw is str(python2 is used) raw[n] will return str,
-            # so for python3 the are no need to call ord to convert str to int.
-            # TODO: Remove this check once we no longer support Python 2
-            if type(raw) == bytes:
-                for n in range(0, num_bytes):
-                    eeprom_raw[n] = hex(raw[n])[2:].zfill(2)
-            else:
-                for n in range(0, num_bytes):
-                    eeprom_raw[n] = hex(ord(raw[n]))[2:].zfill(2)
+            # raw is changed to bytearray to support both python 2 and 3.
+            raw = bytearray(raw)
+            for n in range(0, num_bytes):
+                eeprom_raw[n] = hex(raw[n])[2:].zfill(2)
         except Exception:
             return None
 

--- a/sonic_y_cable/y_cable.py
+++ b/sonic_y_cable/y_cable.py
@@ -10,8 +10,8 @@ try:
     import struct
     from ctypes import c_int8
 
-    import sonic_platform.platform
     from sonic_py_common import logger
+    import sonic_platform.platform
 except ImportError as e:
     # When build python3 xcvrd, it tries to do basic check which will import this file. However,
     # not all platform supports python3 API now, so it could cause an issue when importing


### PR DESCRIPTION

<!-- Provide a general summary of your changes in the Title above -->

#### Description
<!--
     Describe your changes in detail
-->
- Change import order in Ycable helper
- Change data read from EEPROM to bytearray in _read_eeprom_specific_bytes for python 2 and 3 compatibility.

#### Motivation and Context
<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->

https://github.com/Azure/sonic-buildimage/issues/6820
- Import of sonic_platform before logger when platform API is not available leads to non import of logger resulting in xcvrd crash
- Since string and byte comparison returns true in python2 current check for differentiating python2 and 3 in EEPROM read fails.

#### How Has This Been Tested?
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->
Verified that python 2 xcvrd runs without exiting in DellEMC S5248F platform.
Logs: [Unit testing logs.txt](https://github.com/Azure/sonic-platform-common/files/6123278/Unit.testing.logs.txt)

#### Additional Information (Optional)

