### PR TITLE
[Y-Cable] refactor get_firmware_version to comply with all vendors

### DIFF
--- a/sonic_y_cable/y_cable.py
+++ b/sonic_y_cable/y_cable.py
@@ -1240,8 +1240,7 @@ def get_firmware_version(physical_port, target):
 
         result["version_active"] = version_build_slot1 if slot_status & 0x01 else version_build_slot2
         result["version_inactive"] = version_build_slot2 if slot_status & 0x01 else version_build_slot1
-        result["version_next"] = version_build_slot1 if slot_status & 0x02
-        result["version_next"] = version_build_slot2 if slot_status & 0x20
+        result["version_next"] = version_build_slot1 if slot_status & 0x02 else version_build_slot2
 
 
     return result

--- a/sonic_y_cable/y_cable.py
+++ b/sonic_y_cable/y_cable.py
@@ -1224,6 +1224,10 @@ def get_firmware_version(physical_port, target):
         build_slot2 = chr(rev_build_lsb_slot2) + chr(rev_build_msb_slot2)
         version_slot2 = str(rev_major_slot2) + "." + str(rev_minor_slot2)
 
+        '''TODO: the fields with slot number as suffix are redundant and must
+        be removed eventually since they are covered by the fields which
+        have version as prefix. '''
+
         result["build_slot1"] = build_slot1
         result["version_slot1"] = version_slot1
         result["build_slot2"] = build_slot2

--- a/sonic_y_cable/y_cable.py
+++ b/sonic_y_cable/y_cable.py
@@ -1235,6 +1235,15 @@ def get_firmware_version(physical_port, target):
         result["empty_slot1"] = True if slot_status & 0x04 else False
         result["empty_slot2"] = True if slot_status & 0x40 else False
 
+        version_build_slot1 = version_slot1 + build_slot1
+        version_build_slot2 = version_slot2 + build_slot2
+
+        result["version_active"] = version_build_slot1 if slot_status & 0x01 else version_build_slot2
+        result["version_inactive"] = version_build_slot2 if slot_status & 0x01 else version_build_slot1
+        result["version_next"] = version_build_slot1 if slot_status & 0x02
+        result["version_next"] = version_build_slot2 if slot_status & 0x20
+
+
     return result
 
 


### PR DESCRIPTION
Signed-off-by: vaibhav-dahiya <vdahiya@microsoft.com>
This PR refactors the get_firmware_version output to return the following fields for each target. 
```
{
"version_active": "",
"version_inactive": "",
"version_next": "",
```
So by calling this for all the 3 MCU's TOR1, TOR2 and NIC we can get the below result. 

```
{
"version_nic_active": "0.6MS",
"version_nic_inactive": "0.5MS",
"version_nic_next": "0.6MS",
"version_self_active": "0.5MS",
"version_self_inactive": "0.6MS",
"version_self_next": "0.6MS",
"version_peer_active": "0.6MS",
"version_peer_inactive": "0.6MS",
"version_peer_next": "0.6MS",
} 
```

<!-- Provide a general summary of your changes in the Title above -->

#### Description

<!-- 
     Describe your changes in detail
-->

#### Motivation and Context
Required to refactor get_firmware_version output to comply with all vendors output. 
<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->

#### How Has This Been Tested?
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->

#### Additional Information (Optional)

