### PR TITLE
 [DeviceBase] Added hardware revision number to generic device properties

### DIFF
--- a/sonic_platform_base/device_base.py
+++ b/sonic_platform_base/device_base.py
@@ -55,6 +55,15 @@ class DeviceBase(object):
         """
         raise NotImplementedError
 
+    def get_revision(self):
+        """
+        Retrieves the hardware revision number of the device
+
+        Returns:
+            string: Revision number of device
+        """
+        raise NotImplementedError
+
     def get_status(self):
         """
         Retrieves the operational status of the device

--- a/sonic_platform_base/device_base.py
+++ b/sonic_platform_base/device_base.py
@@ -57,10 +57,10 @@ class DeviceBase(object):
 
     def get_revision(self):
         """
-        Retrieves the hardware revision number of the device
+        Retrieves the hardware revision of the device
 
         Returns:
-            string: Revision number of device
+            string: Revision value of device
         """
         raise NotImplementedError
 


### PR DESCRIPTION
#### Description
Added a `get_revision()` method to the generic platform device class which returns the hardware revision number of the device as a string. 

#### Motivation and Context
Exposing the hardware revision number to the platform API allows the user to precisely determine the FRU hardware components installed for debugging and inventory tracking purposes. 
