### PR TITLE
[sonic_sfp] Handle QSFP DD keys gracefully

### DIFF
--- a/sonic_platform_base/sonic_sfp/qsfp_dd.py
+++ b/sonic_platform_base/sonic_sfp/qsfp_dd.py
@@ -92,7 +92,10 @@ class qsfp_dd_InterfaceId(sffbase):
 
     def parse_application(self, sfp_media_type_dict, host_interface, media_interface):
         host_result = host_electrical_interface[host_interface]
-        media_result = sfp_media_type_dict[media_interface]
+        if media_interface in sfp_media_type_dict.keys():
+            media_result = sfp_media_type_dict[media_interface]
+        else:
+            media_result = 'Unknown'
         return host_result, media_result
 
     version = '1.0'


### PR DESCRIPTION

#### Description
xcvrd crashes with the following trace for few media when processing application advertisement.
Traceback (most recent call last):
  File "/usr/local/bin/xcvrd", line 8, in <module>
    sys.exit(main())
  File "/usr/local/lib/python3.7/dist-packages/xcvrd/xcvrd.py", line 1415, in main
    xcvrd.run()
  File "/usr/local/lib/python3.7/dist-packages/xcvrd/xcvrd.py", line 1363, in run
    self.init()
  File "/usr/local/lib/python3.7/dist-packages/xcvrd/xcvrd.py", line 1328, in init
    post_port_sfp_dom_info_to_db(is_warm_start, self.stop_event)
  File "/usr/local/lib/python3.7/dist-packages/xcvrd/xcvrd.py", line 501, in post_port_sfp_dom_info_to_db
    post_port_sfp_info_to_db(logical_port_name, int_tbl[asic_index], transceiver_dict, stop_event)
  File "/usr/local/lib/python3.7/dist-packages/xcvrd/xcvrd.py", line 293, in post_port_sfp_info_to_db
    port_info_dict = _wrapper_get_transceiver_info(physical_port)
  File "/usr/local/lib/python3.7/dist-packages/xcvrd/xcvrd.py", line 164, in _wrapper_get_transceiver_info
    return platform_chassis.get_sfp(physical_port).get_transceiver_info()
  File "/usr/local/lib/python3.7/dist-packages/sonic_platform/sfp.py", line 621, in get_transceiver_info
    sfp_application_type_list[i * 4], sfp_application_type_list[i * 4 + 1])
  File "/usr/local/lib/python3.7/dist-packages/sonic_platform_base/sonic_sfp/qsfp_dd.py", line 95, in parse_application
    media_result = sfp_media_type_dict[media_interface]
KeyError: '88'

#### Motivation and Context
To fix the crash, check whether the media interface key is present before retrieving the particular key in the dict.
#### How Has This Been Tested?
Check whether xcvrd is functioning properly after the fix

#### Additional Information (Optional)

