### PR TITLE
Fix typo for midplane APIs.

### DIFF
--- a/sonic_platform_base/module_base.py
+++ b/sonic_platform_base/module_base.py
@@ -451,7 +451,7 @@ class ModuleBase(device_base.DeviceBase):
             A string, the IP-address of the module reachable over the midplane
 
         """
-        return NotImplementedError
+        raise NotImplementedError
 
     def is_midplane_reachable(self):
         """
@@ -461,4 +461,4 @@ class ModuleBase(device_base.DeviceBase):
         Returns:
             A bool value, should return True if module is reachable via midplane
         """
-        return NotImplementedError
+        raise NotImplementedError


### PR DESCRIPTION
There is typo "return" vs "raise" in midplane APIs.

<!-- Provide a general summary of your changes in the Title above -->

#### Description
In midplane API, default method should be raise NotImplementedError not return NotImplementedError
<!--
     Describe your changes in detail
-->

#### Motivation and Context
In case of platforms don't have the implementation for midplane API, the default value will not be set since there is no exception raised by this function.
<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->

#### How Has This Been Tested?
Run the test on pmon without implementing the method and chassisd won't complain about line:
266                 # Update db with midplane information
267                 fvs = swsscommon.FieldValuePairs([(CHASSIS_MIDPLANE_INFO_IP_FIELD, midplane_ip),
268 B->                                               (CHASSIS_MIDPLANE_INFO_ACCESS_FIELD, str(midplane_access))])

<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->

#### Additional Information (Optional)

