### PR TITLE
Fix decode error when parsing EEPROM fields

### DIFF
--- a/sonic_platform_base/sonic_sfp/sffbase.py
+++ b/sonic_platform_base/sonic_sfp/sffbase.py
@@ -35,7 +35,7 @@ class sffbase(object):
             ret_str = ''
             for n in range(start, end):
                 ret_str += arr[n]
-            return binascii.unhexlify(ret_str).decode("utf-8").strip()
+            return binascii.unhexlify(ret_str).decode("utf-8", "ignore").strip()
         except Exception as err:
             return str(err)
 


### PR DESCRIPTION

#### Description
Following error is seen while parsing EEPROM fields for few transceivers.
'utf-8' codec can't decode byte 0xff in position 6: invalid start byte
#### Motivation and Context
EEPROM fields will not be displayed  if unicode characters are not properly.
E.g. Vendor Date: 20'u-tf--8'
#### How Has This Been Tested?
Check sfpshow eeprom after making the change and verify the behavior.
#### Additional Information (Optional)
[SFP_UT.txt.log](https://github.com/Azure/sonic-platform-common/files/6665180/SFP_UT.txt.log)

