### PR TITLE
Avoid front panel port handling on recirc port

### DIFF
--- a/sonic_platform_base/sonic_sfp/sfputilbase.py
+++ b/sonic_platform_base/sonic_sfp/sfputilbase.py
@@ -15,7 +15,7 @@ try:
     from natsort import natsorted
     from portconfig import get_port_config
     from sonic_py_common import device_info
-    from sonic_py_common.interface import backplane_prefix, inband_prefix
+    from sonic_py_common.interface import backplane_prefix, inband_prefix, recirc_prefix
 
     from sonic_eeprom import eeprom_dts
     from .sff8472 import sff8472InterfaceId  # Dot module supports both Python 2 and Python 3 using explicit relative import methods
@@ -498,8 +498,9 @@ class SfpUtilBase(object):
                 # so we use the port's position in the file (zero-based) as bcm_port
                 portname = line.split()[0]
 
-                # Ignore if this is an internal backplane interface and Inband interface
-                if portname.startswith(backplane_prefix()) or portname.startswith(inband_prefix()):
+                # Ignore if this is an internal backplane, Inband, or recirc interface
+                if portname.startswith(backplane_prefix()) or portname.startswith(inband_prefix()) or \
+                   portname.startswith(recirc_prefix()):
                     continue
 
                 bcm_port = str(port_pos_in_file)

--- a/sonic_platform_base/sonic_sfp/sfputilhelper.py
+++ b/sonic_platform_base/sonic_sfp/sfputilhelper.py
@@ -14,7 +14,7 @@ try:
     from natsort import natsorted
     from portconfig import get_port_config
     from sonic_py_common import device_info
-    from sonic_py_common.interface import backplane_prefix, inband_prefix
+    from sonic_py_common.interface import backplane_prefix, inband_prefix, recirc_prefix
 
 except ImportError as e:
     raise ImportError("%s - required module not found" % str(e))
@@ -127,8 +127,9 @@ class SfpUtilHelper(object):
                 # so we use the port's position in the file (zero-based) as bcm_port
                 portname = line.split()[0]
 
-                # Ignore if this is an internal backplane interface and Inband interface
-                if portname.startswith(backplane_prefix()) or portname.startswith(inband_prefix()):
+                # Ignore if this is an internal backplane, Inband, or recirc interface
+                if portname.startswith(backplane_prefix()) or portname.startswith(inband_prefix()) or \
+                   portname.startswith(recirc_prefix()):
                     continue
 
                 bcm_port = str(port_pos_in_file)


### PR DESCRIPTION
Recirc port is not used as front panel port. So avoid front panel port handling on recirc port.
