### PR TITLE
[sfp] Update lpmode API and add get_power_set

### DIFF
--- a/sonic_platform_base/sfp_base.py
+++ b/sonic_platform_base/sfp_base.py
@@ -248,6 +248,8 @@ class SfpBase(device_base.DeviceBase):
         """
         Retrieves the lpmode (low power mode) status of this SFP
 
+        Raises NotImplementedError if the lpmode pin is not available for this SFP
+
         Returns:
             A Boolean, True if lpmode is enabled, False if disabled
         """
@@ -259,6 +261,15 @@ class SfpBase(device_base.DeviceBase):
 
         Returns:
             A Boolean, True if power-override is enabled, False if disabled
+        """
+        raise NotImplementedError
+
+    def get_power_set(self):
+        """
+        Retrieves the power-set status of this SFP
+
+        Returns:
+            A Boolean, True if power-set is enabled, False if disabled
         """
         raise NotImplementedError
 
@@ -354,6 +365,8 @@ class SfpBase(device_base.DeviceBase):
     def set_lpmode(self, lpmode):
         """
         Sets the lpmode (low power mode) of SFP
+
+        Raises NotImplementedError if the lpmode pin is not available for this SFP
 
         Args:
             lpmode: A Boolean, True to enable lpmode, False to disable it


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

#### Description
- Add get_power_set() method for retrieving the power-set status of the SFP
- Update lpmode accessors to indicate raising NotImplementedError as expected behaviour if not supported on a platform

#### Motivation and Context
<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->
Some platforms do not have a controllable lpmode pin that can be used to access the lpmode status of a xcvr. However, the xcvr itself may have a controllable lpmode mechanism via its EEPROM. To make use of this, platforms that don't have a controllable lpmode pin should raise NotImplementedError. Common code (like sfputil) will be updated in a subsequent PR to use the EEPROM lpmode mechanism instead when NotImplementedError is raised from using the lpmode API.

Adding a new get_power_set method because it will be used to determine the lpmode status of a xcvr when making use of the EEPROM lpmode mechanism (i.e. if power_override is true, then lpmode == power_set).

#### How Has This Been Tested?
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->
Nothing to test as this is just adding a new abstract method.
#### Additional Information (Optional)

