### PR TITLE
Fix Xcvrd crash due to invalid key access in type_of_media_interface, host_electrical_interface, connector_dict

### DIFF
--- a/sonic_platform_base/sonic_sfp/qsfp_dd.py
+++ b/sonic_platform_base/sonic_sfp/qsfp_dd.py
@@ -46,7 +46,10 @@ class qsfp_dd_InterfaceId(sffbase):
 
     def decode_connector(self, eeprom_data, offset, size):
         connector_id = eeprom_data[offset]
-        return connector_dict[connector_id]
+        if connector_id in connector_dict.keys():
+            return connector_dict[connector_id]
+        else:
+            return 'N/A'
 
     def decode_ext_id(self, eeprom_data, offset, size):
         # bits 5-7 represent Module Card Power Class
@@ -213,7 +216,7 @@ class qsfp_dd_InterfaceId(sffbase):
 
     def parse_vendor_date(self, date_raw_data, start_pos):
         return sffbase.parse(self, self.vendor_date, date_raw_data, start_pos)
-    
+
     def parse_vendor_oui(self, vendor_oui_data, start_pos):
         return sffbase.parse(self, self.vendor_oui, vendor_oui_data, start_pos)
 
@@ -700,7 +703,7 @@ class qsfp_dd_Dom(sffbase):
     def parse_channel_monitor_params(self, eeprom_raw_data, start_pos):
         return sffbase.parse(self, self.dom_channel_monitor_params, eeprom_raw_data,
                     start_pos)
-    
+
     def parse_dom_tx_bias(self, eeprom_raw_data, start_pos):
         return sffbase.parse(self, self.dom_tx_bias, eeprom_raw_data,
                     start_pos)

--- a/sonic_platform_base/sonic_sfp/qsfp_dd.py
+++ b/sonic_platform_base/sonic_sfp/qsfp_dd.py
@@ -79,7 +79,12 @@ class qsfp_dd_InterfaceId(sffbase):
 
     def decode_media_type(self, eeprom_data, offset, size):
         media_type_code = eeprom_data[0]
+
+        if media_type_code not in type_of_media_interface.keys():
+            return None
+
         dict_name = type_of_media_interface[media_type_code]
+
         if dict_name == "nm_850_media_interface":
             return nm_850_media_interface
         elif dict_name == "sm_media_interface":

--- a/sonic_platform_base/sonic_sfp/qsfp_dd.py
+++ b/sonic_platform_base/sonic_sfp/qsfp_dd.py
@@ -99,11 +99,14 @@ class qsfp_dd_InterfaceId(sffbase):
              return None
 
     def parse_application(self, sfp_media_type_dict, host_interface, media_interface):
-        host_result = host_electrical_interface[host_interface]
+        media_result = 'Unknown'
+        host_result = 'Unknown'
+
+        if host_interface in host_electrical_interface:
+            host_result = host_electrical_interface[host_interface]
+
         if media_interface in sfp_media_type_dict.keys():
             media_result = sfp_media_type_dict[media_interface]
-        else:
-            media_result = 'Unknown'
         return host_result, media_result
 
     version = '1.0'


### PR DESCRIPTION
Signed-off-by: Prince George <prgeor@microsoft.com>


#### Description

Fix for xcvrd crashes with the following trace:-

Jul  7 19:18:00.910456 str-DellEmc-z9332f-032 INFO pmon#/supervisord: message repeated 3 times: [ pcied Platform PCIe Configuration file doesn't exist!]
Jul  7 19:18:00.910586 str-DellEmc-z9332f-032 INFO pmon#/supervisord: xcvrd Traceback (most recent call last):
Jul  7 19:18:00.910656 str-DellEmc-z9332f-032 INFO pmon#/supervisord: xcvrd   File "/usr/local/bin/xcvrd", line 8, in <module>
Jul  7 19:18:00.910722 str-DellEmc-z9332f-032 INFO pmon#/supervisord: xcvrd     sys.exit(main())
Jul  7 19:18:00.910789 str-DellEmc-z9332f-032 INFO pmon#/supervisord: xcvrd   File "/usr/local/lib/python3.7/dist-packages/xcvrd/xcvrd.py", line 1416, in main
Jul  7 19:18:00.910858 str-DellEmc-z9332f-032 INFO pmon#/supervisord: xcvrd     xcvrd.run()
Jul  7 19:18:00.910920 str-DellEmc-z9332f-032 INFO pmon#/supervisord: xcvrd   File "/usr/local/lib/python3.7/dist-packages/xcvrd/xcvrd.py", line 1364, in run
Jul  7 19:18:00.910989 str-DellEmc-z9332f-032 INFO pmon#/supervisord: xcvrd     self.init()
Jul  7 19:18:00.911059 str-DellEmc-z9332f-032 INFO pmon#/supervisord: xcvrd   File "/usr/local/lib/python3.7/dist-packages/xcvrd/xcvrd.py", line 1327, in init
Jul  7 19:18:00.911125 str-DellEmc-z9332f-032 INFO pmon#/supervisord: xcvrd     post_port_sfp_dom_info_to_db(is_warm_start, self.stop_event)
Jul  7 19:18:00.911193 str-DellEmc-z9332f-032 INFO pmon#/supervisord: xcvrd   File "/usr/local/lib/python3.7/dist-packages/xcvrd/xcvrd.py", line 500, in post_port_sfp_dom_info_to_db
Jul  7 19:18:00.911258 str-DellEmc-z9332f-032 INFO pmon#/supervisord: xcvrd     post_port_sfp_info_to_db(logical_port_name, int_tbl[asic_index], transceiver_dict, stop_event)
Jul  7 19:18:00.911326 str-DellEmc-z9332f-032 INFO pmon#/supervisord: xcvrd   File "/usr/local/lib/python3.7/dist-packages/xcvrd/xcvrd.py", line 292, in post_port_sfp_info_to_db
Jul  7 19:18:00.911394 str-DellEmc-z9332f-032 INFO pmon#/supervisord: xcvrd     port_info_dict = _wrapper_get_transceiver_info(physical_port)
Jul  7 19:18:00.911461 str-DellEmc-z9332f-032 INFO pmon#/supervisord: xcvrd   File "/usr/local/lib/python3.7/dist-packages/xcvrd/xcvrd.py", line 163, in _wrapper_get_transceiver_info
Jul  7 19:18:00.911531 str-DellEmc-z9332f-032 INFO pmon#/supervisord: xcvrd     return platform_chassis.get_sfp(physical_port).get_transceiver_info()
Jul  7 19:18:00.911598 str-DellEmc-z9332f-032 INFO pmon#/supervisord: xcvrd   File "/usr/local/lib/python3.7/dist-packages/sonic_platform/sfp.py", line 542, in get_transceiver_info
Jul  7 19:18:00.911665 str-DellEmc-z9332f-032 INFO pmon#/supervisord: xcvrd     connector = self._get_eeprom_data('connector')
Jul  7 19:18:00.911733 str-DellEmc-z9332f-032 INFO pmon#/supervisord: xcvrd   File "/usr/local/lib/python3.7/dist-packages/sonic_platform/sfp.py", line 392, in _get_eeprom_data
Jul  7 19:18:00.911801 str-DellEmc-z9332f-032 INFO pmon#/supervisord: xcvrd     eeprom_data_raw, 0)
Jul  7 19:18:00.911867 str-DellEmc-z9332f-032 INFO pmon#/supervisord: xcvrd   File "/usr/local/lib/python3.7/dist-packages/sonic_platform_base/sonic_sfp/qsfp_dd.py", line 221, in parse_connector
Jul  7 19:18:00.911933 str-DellEmc-z9332f-032 INFO pmon#/supervisord: xcvrd     return sffbase.parse(self, self.connector, connector_data, start_pos)
Jul  7 19:18:00.911998 str-DellEmc-z9332f-032 INFO pmon#/supervisord: xcvrd   File "/usr/local/lib/python3.7/dist-packages/sonic_platform_base/sonic_sfp/sffbase.py", line 186, in parse
Jul  7 19:18:00.912065 str-DellEmc-z9332f-032 INFO pmon#/supervisord: xcvrd     outdict = self.parse_sff(eeprom_map, eeprom_data, start_pos)
Jul  7 19:18:00.912143 str-DellEmc-z9332f-032 INFO pmon#/supervisord: xcvrd   File "/usr/local/lib/python3.7/dist-packages/sonic_platform_base/sonic_sfp/sffbase.py", line 158, in parse_sff
Jul  7 19:18:00.912233 str-DellEmc-z9332f-032 INFO pmon#/supervisord: xcvrd     meta_data, start_pos)
Jul  7 19:18:00.912324 str-DellEmc-z9332f-032 INFO pmon#/supervisord: xcvrd   File "/usr/local/lib/python3.7/dist-packages/sonic_platform_base/sonic_sfp/sffbase.py", line 127, in parse_sff_element
Jul  7 19:18:00.912395 str-DellEmc-z9332f-032 INFO pmon#/supervisord: xcvrd     offset, size)
Jul  7 19:18:00.912465 str-DellEmc-z9332f-032 INFO pmon#/supervisord: xcvrd   File "/usr/local/lib/python3.7/dist-packages/sonic_platform_base/sonic_sfp/qsfp_dd.py", line 49, in decode_connector
Jul  7 19:18:00.912533 str-DellEmc-z9332f-032 INFO pmon#/supervisord: xcvrd     return connector_dict[connector_id]
Jul  7 19:18:00.912603 str-DellEmc-z9332f-032 INFO pmon#/supervisord: xcvrd KeyError: 'ff'
Jul  7 19:18:00.939018 str-DellEmc-z9332f-032 INFO pmon#supervisord 2021-07-07 19:18:00,938 INFO exited: xcvrd (exit status 1; not expected)
Jul  7 19:18:01.651780 str-DellEmc-z9332f-032 NOTICE pmon#psud[44]: PSU absence warning cleared: PSU 1 is inserted back.



#### Motivation and Context

 Due to wrong page selection, the eeprom read returned a value 0xff which was an invalid key into connector_dict[]. Now we verify the key validity before accessing the dict element. The fix for why the eeprom read returned 0xff is being investigated separately.


#### How Has This Been Tested?

Verified no xcvrd crash across multiple reboots on str-DellEmc-z9332f-032. 


#### Additional Information (Optional)

