### PR TITLE
Revert "Unifying the platform api for get_pcie_aer_stats with PcieBase (#197)"

### DIFF
--- a/sonic_platform_base/sonic_pcie/pcie_common.py
+++ b/sonic_platform_base/sonic_pcie/pcie_common.py
@@ -27,7 +27,7 @@ class PcieUtil(PcieBase):
         config_file = "{}/pcie{}.yaml".format(self.config_path, conf_rev)
         try:
             with open(config_file) as conf_file:
-                self.confInfo = yaml.safe_load(conf_file)
+                self.confInfo = yaml.load(conf_file)
         except IOError as e:
             print("Error: {}".format(str(e)))
             print("Not found config file, please add a config file manually, or generate it by running [pcieutil pcie_generate]")
@@ -101,9 +101,9 @@ class PcieUtil(PcieBase):
         return self.confInfo
 
     # return AER stats of PCIe device
-    def get_pcie_aer_stats(self, domain=0, bus=0, dev=0, func=0):
+    def get_pcie_aer_stats(self, domain=0, bus=0, device=0, func=0):
         aer_stats = {'correctable': {}, 'fatal': {}, 'non_fatal': {}}
-        dev_path = os.path.join('/sys/bus/pci/devices', '%04x:%02x:%02x.%d' % (domain, bus, dev, func))
+        dev_path = os.path.join('/sys/bus/pci/devices', '%04x:%02x:%02x.%d' % (domain, bus, device, func))
 
         # construct AER sysfs filepath
         correctable_path = os.path.join(dev_path, "aer_dev_correctable")


### PR DESCRIPTION
This reverts commit 238d76b2f27bb0a1413e08779035906b953a0ac3.
Due to build broken on sonic-platform-daemons

<!-- Provide a general summary of your changes in the Title above -->

#### Description
<!--
     Describe your changes in detail
-->

#### Motivation and Context
<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->

#### How Has This Been Tested?
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->

#### Additional Information (Optional)

