### PR TITLE
[Y-Cable] add the definition inside setup.py to include sonic_y_cabe.credo as a package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,7 @@ setup(
         'sonic_sfp',
         'sonic_thermal',
         'sonic_y_cable',
+        'sonic_y_cable.credo',
     ],
     # NOTE: Install also depends on sonic-config-engine for portconfig.py
     # This dependency should be eliminated by moving portconfig.py


### PR DESCRIPTION
Curreently the way python wheel includes packages is all the subdirectories inside a package need to be also included
for them to be a package. Since in the refactor for multiple vendor Y-Cable xcvrd calls these vendor specific modules by including their name which it obtains by reading the eeprom it is required to include them inside setup.py for the wheel to know it has a package. 

Signed-off-by: vaibhav-dahiya <vdahiya@microsoft.com>

<!-- Provide a general summary of your changes in the Title above -->

#### Description
add the definition inside setup.py to include sonic_y_cabe.credo as a package
<!--
     Describe your changes in detail
-->

#### Motivation and Context
This is required by all calling API's for vendor agnostic Y-Cable API's to be called for credo specific cables.
<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->

#### How Has This Been Tested?
Built an image and validated the presence of the pacakge.
Ran the API's on a Arista7050cx3 switch.
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->

#### Additional Information (Optional)

