### PR TITLE
[sonic_xcvr] Pre-emphasis settings fails for CMIS devices

### DIFF
--- a/sonic_platform_base/sonic_xcvr/api/public/cmis.py
+++ b/sonic_platform_base/sonic_xcvr/api/public/cmis.py
@@ -40,7 +40,7 @@ class CmisApi(XcvrApi):
             "encoding": "N/A", # Not supported
             "ext_identifier": "%s (%sW Max)" % (power_class, max_power),
             "ext_rateselect_compliance": "N/A", # Not supported
-            "cable_type": "Length cable Assembly(m)",
+            "cable_type": "Length Cable Assembly(m)",
             "cable_length": float(admin_info[consts.LENGTH_ASSEMBLY_FIELD]),
             "nominal_bit_rate": 0, # Not supported
             "specification_compliance": media_type,


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

#### Description
Pre-emphasis settings for CMIS devices is not set as cable length field is not set in xcvrd.

#### Motivation and Context
Other media types uses "Length Cable Assembly" as cable type. As cable filed is defined in small letters, it failed in xcvrd for CMIS devices.
https://github.com/Azure/sonic-platform-daemons/blob/e5165b79dfe722052ea86694e5fe98429c735e36/sonic-xcvrd/xcvrd/xcvrd.py#L625
#### How Has This Been Tested?
Tested in DellEMC Z9332f platform.
[cable_len_UT.txt](https://github.com/Azure/sonic-platform-common/files/7494480/cable_len_UT.txt)

#### Additional Information (Optional)

