### PR TITLE
Add missing cmis package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,7 @@ setup(
         'sonic_platform_base.sonic_thermal_control',
         'sonic_platform_base.sonic_xcvr',
         'sonic_platform_base.sonic_xcvr.fields',
+        'sonic_platform_base.sonic_xcvr.fields.public',
         'sonic_platform_base.sonic_xcvr.mem_maps',
         'sonic_platform_base.sonic_xcvr.mem_maps.public',
         'sonic_platform_base.sonic_xcvr.api',


### PR DESCRIPTION
Signed-off-by: Prince George <prgeor@microsoft.com>

<!-- Provide a general summary of your changes in the Title above -->

#### Description
Added missing cmis package to be included during python wheel build

#### Motivation and Context
To fix build error while taking the latest changes from sonic-platform-common in sonic-buildimage repo:-
```
2021-11-15T04:23:19.5414058Z     from .mock_platform import MockChassis, MockFan, MockPsu
2021-11-15T04:23:19.5414420Z tests/mock_platform.py:1: in <module>
2021-11-15T04:23:19.5414747Z     from sonic_platform_base import chassis_base
2021-11-15T04:23:19.5415385Z /usr/local/lib/python2.7/dist-packages/sonic_platform_base/__init__.py:9: in <module>
2021-11-15T04:23:19.5415757Z     from . import sfp_base
2021-11-15T04:23:19.5416346Z /usr/local/lib/python2.7/dist-packages/sonic_platform_base/sfp_base.py:11: in <module>
2021-11-15T04:23:19.5416768Z     from .sonic_xcvr.xcvr_api_factory import XcvrApiFactory
2021-11-15T04:23:19.5417467Z /usr/local/lib/python2.7/dist-packages/sonic_platform_base/sonic_xcvr/xcvr_api_factory.py:13: in <module>
2021-11-15T04:23:19.5417905Z     from .mem_maps.public.cmis import CmisMemMap
2021-11-15T04:23:19.5418571Z /usr/local/lib/python2.7/dist-packages/sonic_platform_base/sonic_xcvr/mem_maps/public/cmis.py:18: in <module>
2021-11-15T04:23:19.5419030Z     from ...fields.public.cmis import CableLenField
2021-11-15T04:23:19.5419408Z E   ImportError: No module named public.cmis
```

#### How Has This Been Tested?
Local build of the target passes

#### Additional Information (Optional)

