### PR TITLE
[SFP-Refactor] Implement CMIS Low Power mode

### DIFF
--- a/sonic_platform_base/sonic_xcvr/api/public/c_cmis.py
+++ b/sonic_platform_base/sonic_xcvr/api/public/c_cmis.py
@@ -122,11 +122,11 @@ class CCmisApi(CmisApi):
         assert channel_number % 3 == 0
         if channel_number > hi_ch_num or channel_number < low_ch_num:
             raise ValueError('Provisioned frequency out of range. Max Freq: 196100; Min Freq: 191300 GHz.')
-        self.set_low_power(True)
+        self.set_lpmode(True)
         time.sleep(5)
         status = self.xcvr_eeprom.write(consts.LASER_CONFIG_CHANNEL, channel_number)
         time.sleep(1)
-        self.set_low_power(False)
+        self.set_lpmode(False)
         time.sleep(1)
         return status
 

--- a/sonic_platform_base/sonic_xcvr/api/public/cmis.py
+++ b/sonic_platform_base/sonic_xcvr/api/public/cmis.py
@@ -833,16 +833,6 @@ class CmisApi(XcvrApi):
         else:
             return True
 
-    def set_low_power(self, AssertLowPower):
-        '''
-        This function sets the module to low power state.
-        AssertLowPower being 0 means "set to high power"
-        AssertLowPower being 1 means "set to low power"
-        Return True if the provision succeeds, False if it fails
-        '''
-        low_power_control = AssertLowPower << 6
-        return self.xcvr_eeprom.write(consts.MODULE_LEVEL_CONTROL, low_power_control)
-
     def get_lpmode(self):
         '''
         Retrieves Low power module status

--- a/sonic_platform_base/sonic_xcvr/api/public/cmis.py
+++ b/sonic_platform_base/sonic_xcvr/api/public/cmis.py
@@ -833,6 +833,16 @@ class CmisApi(XcvrApi):
         else:
             return True
 
+    def set_low_power(self, AssertLowPower):
+        '''
+        This function sets the module to low power state.
+        AssertLowPower being 0 means "set to high power"
+        AssertLowPower being 1 means "set to low power"
+        Return True if the provision succeeds, False if it fails
+        '''
+        low_power_control = AssertLowPower << 6
+        return self.xcvr_eeprom.write(consts.MODULE_LEVEL_CONTROL, low_power_control)
+
     def get_lpmode(self):
         '''
         Retrieves Low power module status

--- a/sonic_platform_base/sonic_xcvr/api/public/cmis.py
+++ b/sonic_platform_base/sonic_xcvr/api/public/cmis.py
@@ -836,6 +836,7 @@ class CmisApi(XcvrApi):
     def get_lpmode(self):
         '''
         Retrieves Low power module status
+        Returns True if module in low power else returns False.
         '''
         if self.is_flat_memory() or not self.get_lpmode_support():
             return False
@@ -863,7 +864,9 @@ class CmisApi(XcvrApi):
                 lpmode_val = lpmode_val | (1 << 4)
             else:
                 lpmode_val = lpmode_val & ~(1 << 4)
-            return self.xcvr_eeprom.write(consts.MODULE_LEVEL_CONTROL, lpmode_val)
+            self.xcvr_eeprom.write(consts.MODULE_LEVEL_CONTROL, lpmode_val)
+            time.sleep(0.1)
+            return self.get_lpmode()
         return False
 
     def get_loopback_capability(self):

--- a/sonic_platform_base/sonic_xcvr/fields/consts.py
+++ b/sonic_platform_base/sonic_xcvr/fields/consts.py
@@ -259,7 +259,7 @@ WAVELENGTH_UNLOCKED = "TxWavelengthUnlocked"
 LASER_TUNING_DETAIL = "TxTuningDetail"
 
 # CONFIG
-TRANS_CONFIG_FIELD = "TransceriverConfig"
+TRANS_CONFIG_FIELD = "TransceiverConfig"
 MODULE_LEVEL_CONTROL = "ModuleControl"
 
 CTRLS_ADVT_FIELD = "Supported Controls Advertisement"

--- a/sonic_platform_base/sonic_xcvr/sfp_optoe_base.py
+++ b/sonic_platform_base/sonic_xcvr/sfp_optoe_base.py
@@ -128,6 +128,14 @@ class SfpOptoeBase(SfpBase):
     def get_eeprom_path(self):
         raise NotImplementedError
 
+    def get_lpmode(self):
+        api = self.get_xcvr_api()
+        return api.get_lpmode() if api is not None else None
+
+    def set_lpmode(self, lpmode):
+        api = self.get_xcvr_api()
+        return api.set_lp_mode(lpmode) if api is not None else None
+
     def read_eeprom(self, offset, num_bytes):
         try:
             with open(self.get_eeprom_path(), mode='rb', buffering=0) as f:

--- a/sonic_platform_base/sonic_xcvr/sfp_optoe_base.py
+++ b/sonic_platform_base/sonic_xcvr/sfp_optoe_base.py
@@ -129,10 +129,20 @@ class SfpOptoeBase(SfpBase):
         raise NotImplementedError
 
     def get_lpmode(self):
+        """
+        This common API is applicable only for CMIS as Low Power mode can be verified
+        using EEPROM registers.For other media types like QSFP28/QSFP+ etc., platform
+        vendors has to implement accordingly.
+        """
         api = self.get_xcvr_api()
         return api.get_lpmode() if api is not None else None
 
     def set_lpmode(self, lpmode):
+        """
+        This common API is applicable only for CMIS as Low Power mode can be controlled 
+        via EEPROM registers.For other media types like QSFP28/QSFP+ etc., platform
+        vendors has to implement accordingly.
+        """
         api = self.get_xcvr_api()
         return api.set_lp_mode(lpmode) if api is not None else None
 

--- a/tests/sonic_xcvr/test_ccmis.py
+++ b/tests/sonic_xcvr/test_ccmis.py
@@ -97,6 +97,10 @@ class TestCCmis(object):
         (195950, (0xff, -72, 120, 191300, 196100)),
     ])
     def test_set_laser_freq(self, input_param, mock_response):
+        self.api.is_flat_memory = MagicMock()
+        self.api.is_flat_memory.return_value = False
+        self.api.get_lpmode_support = MagicMock()
+        self.api.get_lpmode_support.return_value = False
         self.api.get_supported_freq_config = MagicMock()
         self.api.get_supported_freq_config.return_value = mock_response
         self.api.set_laser_freq(input_param)

--- a/tests/sonic_xcvr/test_ccmis.py
+++ b/tests/sonic_xcvr/test_ccmis.py
@@ -101,8 +101,6 @@ class TestCCmis(object):
         self.api.is_flat_memory.return_value = False
         self.api.get_lpmode_support = MagicMock()
         self.api.get_lpmode_support.return_value = False
-        self.api.xcvr_eeprom.read = MagicMock()
-        self.api.xcvr_eeprom.return_value = False
         self.api.get_supported_freq_config = MagicMock()
         self.api.get_supported_freq_config.return_value = mock_response
         self.api.set_laser_freq(input_param)

--- a/tests/sonic_xcvr/test_ccmis.py
+++ b/tests/sonic_xcvr/test_ccmis.py
@@ -101,6 +101,8 @@ class TestCCmis(object):
         self.api.is_flat_memory.return_value = False
         self.api.get_lpmode_support = MagicMock()
         self.api.get_lpmode_support.return_value = False
+        self.api.xcvr_eeprom.read = MagicMock()
+        self.api.xcvr_eeprom.return_value = False
         self.api.get_supported_freq_config = MagicMock()
         self.api.get_supported_freq_config.return_value = mock_response
         self.api.set_laser_freq(input_param)

--- a/tests/sonic_xcvr/test_cmis.py
+++ b/tests/sonic_xcvr/test_cmis.py
@@ -782,7 +782,14 @@ class TestCmis(object):
     def test_reset_module(self):
         self.api.reset_module(True)
 
-    def test_set_low_power(self):
+    @pytest.mark.parametrize("mock_response, expected", [
+        (True, True)
+    ])
+    def test_set_low_power(self, mock_response, expected):
+        self.api.is_flat_memory = MagicMock()
+        self.api.is_flat_memory.return_value = False
+        self.api.get_lpmode_support = MagicMock()
+        self.api.get_lpmode_support.return_value = False
         self.api.set_lpmode(True)
 
     @pytest.mark.parametrize("mock_response, expected", [

--- a/tests/sonic_xcvr/test_cmis.py
+++ b/tests/sonic_xcvr/test_cmis.py
@@ -783,7 +783,7 @@ class TestCmis(object):
         self.api.reset_module(True)
 
     def test_set_low_power(self):
-        self.api.set_low_power(True)
+        self.api.set_lpmode(True)
 
     @pytest.mark.parametrize("mock_response, expected", [
         (127,

--- a/tests/sonic_xcvr/test_cmis.py
+++ b/tests/sonic_xcvr/test_cmis.py
@@ -782,10 +782,7 @@ class TestCmis(object):
     def test_reset_module(self):
         self.api.reset_module(True)
 
-    @pytest.mark.parametrize("mock_response, expected", [
-        (True, True)
-    ])
-    def test_set_low_power(self, mock_response, expected):
+    def test_set_low_power(self):
         self.api.is_flat_memory = MagicMock()
         self.api.is_flat_memory.return_value = False
         self.api.get_lpmode_support = MagicMock()

--- a/tests/sonic_xcvr/test_cmis.py
+++ b/tests/sonic_xcvr/test_cmis.py
@@ -782,7 +782,7 @@ class TestCmis(object):
     def test_reset_module(self):
         self.api.reset_module(True)
 
-    def test_set_low_power(self, ):
+    def test_set_low_power(self):
         self.api.set_lpmode(True)
 
     @pytest.mark.parametrize("mock_response, expected", [

--- a/tests/sonic_xcvr/test_cmis.py
+++ b/tests/sonic_xcvr/test_cmis.py
@@ -782,7 +782,12 @@ class TestCmis(object):
     def test_reset_module(self):
         self.api.reset_module(True)
 
+    @pytest.mark.parametrize("mock_response, expected", [
+        False, False ])
+
     def test_set_low_power(self):
+        self.api.xcvr_eeprom.read = MagicMock()
+        self.api.xcvr_eeprom.read.side_effect = mock_response
         self.api.set_lpmode(True)
 
     @pytest.mark.parametrize("mock_response, expected", [

--- a/tests/sonic_xcvr/test_cmis.py
+++ b/tests/sonic_xcvr/test_cmis.py
@@ -787,7 +787,7 @@ class TestCmis(object):
     def test_set_low_power(self, mock_response, expected):
         self.api.xcvr_eeprom.read = MagicMock()
         self.api.xcvr_eeprom.read.return_value = mock_response
-        result = self.api.set_low_power(True)
+        result = self.api.set_lpmode(True)
         assert result == expected
 
     @pytest.mark.parametrize("mock_response, expected", [

--- a/tests/sonic_xcvr/test_cmis.py
+++ b/tests/sonic_xcvr/test_cmis.py
@@ -784,11 +784,11 @@ class TestCmis(object):
 
     @pytest.mark.parametrize("mock_response, expected", [
         False, False ])
-
-    def test_set_low_power(self):
+    def test_set_low_power(self, mock_response, expected):
         self.api.xcvr_eeprom.read = MagicMock()
         self.api.xcvr_eeprom.read.side_effect = mock_response
-        self.api.set_lpmode(True)
+        result = self.api.set_low_power(True)
+        assert result == expected
 
     @pytest.mark.parametrize("mock_response, expected", [
         (127,

--- a/tests/sonic_xcvr/test_cmis.py
+++ b/tests/sonic_xcvr/test_cmis.py
@@ -783,10 +783,10 @@ class TestCmis(object):
         self.api.reset_module(True)
 
     @pytest.mark.parametrize("mock_response, expected", [
-        False, False ])
+        True, True ])
     def test_set_low_power(self, mock_response, expected):
         self.api.xcvr_eeprom.read = MagicMock()
-        self.api.xcvr_eeprom.read.side_effect = mock_response
+        self.api.xcvr_eeprom.read.return_value = mock_response
         result = self.api.set_low_power(True)
         assert result == expected
 

--- a/tests/sonic_xcvr/test_cmis.py
+++ b/tests/sonic_xcvr/test_cmis.py
@@ -783,7 +783,7 @@ class TestCmis(object):
         self.api.reset_module(True)
 
     def test_set_low_power(self, ):
-        self.api.set_low_power(True)
+        self.api.set_lpmode(True)
 
     @pytest.mark.parametrize("mock_response, expected", [
         (127,

--- a/tests/sonic_xcvr/test_cmis.py
+++ b/tests/sonic_xcvr/test_cmis.py
@@ -782,7 +782,7 @@ class TestCmis(object):
     def test_reset_module(self):
         self.api.reset_module(True)
 
-    def test_set_low_power(self, mock_response, expected):
+    def test_set_low_power(self):
         self.api.set_low_power(True)
 
     @pytest.mark.parametrize("mock_response, expected", [

--- a/tests/sonic_xcvr/test_cmis.py
+++ b/tests/sonic_xcvr/test_cmis.py
@@ -782,13 +782,8 @@ class TestCmis(object):
     def test_reset_module(self):
         self.api.reset_module(True)
 
-    @pytest.mark.parametrize("mock_response, expected", [
-        True, True ])
     def test_set_low_power(self, mock_response, expected):
-        self.api.xcvr_eeprom.read = MagicMock()
-        self.api.xcvr_eeprom.read.return_value = mock_response
-        result = self.api.set_lpmode(True)
-        assert result == expected
+        self.api.set_low_power(True)
 
     @pytest.mark.parametrize("mock_response, expected", [
         (127,


### PR DESCRIPTION
**Description**
Add LP mode support for CMIS devices.

**Motivation and Context**
Low Power mode can be set in CMIS devices by reading/writing in EEPROM.

**How Has This Been Tested?**
Tested in DellEMC Z9332f platform.
