### PR TITLE
Remove time counting message in firmware related functions 

### DIFF
--- a/sonic_platform_base/sonic_xcvr/api/public/cmis.py
+++ b/sonic_platform_base/sonic_xcvr/api/public/cmis.py
@@ -1055,7 +1055,7 @@ class CmisApi(XcvrApi):
             txt += 'Reply payload check code error\n'
             return {'status': False, 'info': txt, 'result': None}
         elapsedtime = time.time()-starttime
-        txt += 'Get module FW upgrade features time: %.2f s\n' %elapsedtime
+        logger.info('Get module FW upgrade features time: %.2f s\n' %elapsedtime)
         logger.info(txt)
         return {'status': True, 'info': txt, 'result': (startLPLsize, maxblocksize, lplonly_flag, autopaging_flag, writelength)}
 
@@ -1125,7 +1125,7 @@ class CmisApi(XcvrApi):
             txt += 'Reply payload check code error\n'
             return {'status': False, 'info': txt, 'result': None}
         elapsedtime = time.time()-starttime
-        txt += 'Get module FW info time: %.2f s\n' %elapsedtime
+        logger.info('Get module FW info time: %.2f s\n' %elapsedtime)
         logger.info(txt)
         return {'status': True, 'info': txt, 'result': (ImageA, ImageARunning, ImageACommitted, ImageAValid, ImageB, ImageBRunning, ImageBCommitted, ImageBValid)}
 
@@ -1168,7 +1168,7 @@ class CmisApi(XcvrApi):
             txt += 'FW_run_status %d\n' %fw_run_status
             return False, txt
         elapsedtime = time.time()-starttime
-        txt += 'Module FW run time: %.2f s\n' %elapsedtime
+        logger.info('Module FW run time: %.2f s\n' %elapsedtime)
         logger.info(txt)
         return True, txt
 
@@ -1203,7 +1203,7 @@ class CmisApi(XcvrApi):
             txt += 'FW_commit_status %d\n' %fw_commit_status
             return False, txt
         elapsedtime = time.time()-starttime
-        txt += 'Module FW commit time: %.2f s\n' %elapsedtime
+        logger.info('Module FW commit time: %.2f s\n' %elapsedtime)
         logger.info(txt)
         return True, txt
 

--- a/tests/sonic_xcvr/test_cmis.py
+++ b/tests/sonic_xcvr/test_cmis.py
@@ -922,13 +922,13 @@ class TestCmis(object):
             False,
             [0x77, 0xff],
             [18, 35, (0, 7, 112, 255, 255, 16, 0, 0, 19, 136, 0, 100, 3, 232, 19, 136, 58, 152)],
-            {'status':True, 'info': 'Auto page support: True\nMax write length: 2048\nStart payload size 112\nMax block size 2048\nWrite to EPL supported\nAbort CMD102h supported True\nGet module FW upgrade features time: 0.00 s\n', 'result': (112, 2048, False, True, 2048)}
+            {'status':True, 'info': 'Auto page support: True\nMax write length: 2048\nStart payload size 112\nMax block size 2048\nWrite to EPL supported\nAbort CMD102h supported True\n', 'result': (112, 2048, False, True, 2048)}
         ),
         (
             False,
             [0x77, 0xff],
             [18, 35, (0, 7, 112, 255, 255, 1, 0, 0, 19, 136, 0, 100, 3, 232, 19, 136, 58, 152)],
-            {'status':True, 'info': 'Auto page support: True\nMax write length: 2048\nStart payload size 112\nMax block size 2048\nWrite to LPL supported\nAbort CMD102h supported True\nGet module FW upgrade features time: 0.00 s\n', 'result': (112, 2048, True, True, 2048)}
+            {'status':True, 'info': 'Auto page support: True\nMax write length: 2048\nStart payload size 112\nMax block size 2048\nWrite to LPL supported\nAbort CMD102h supported True\n', 'result': (112, 2048, True, True, 2048)}
         ),
     ])
     def test_get_module_fw_upgrade_feature(self, input_param, mock_response1, mock_response2, expected):
@@ -945,11 +945,11 @@ class TestCmis(object):
     @pytest.mark.parametrize("mock_response, expected", [
         (
             [110, 26, (3, 3, 0, 0, 0, 1, 1, 4, 3, 0, 0, 100, 3, 232, 19, 136, 58, 152, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 4, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2, 1, 0, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)],
-            {'status':True, 'info': 'Get module FW info\nImage A Version: 0.0.1\nImage B Version: 0.0.0\nRunning Image: A; Committed Image: A\nGet module FW info time: 0.00 s\n', 'result': ('0.0.1', 1, 1, 0, '0.0.0', 0, 0, 0)}
+            {'status':True, 'info': 'Get module FW info\nImage A Version: 0.0.1\nImage B Version: 0.0.0\nRunning Image: A; Committed Image: A\n', 'result': ('0.0.1', 1, 1, 0, '0.0.0', 0, 0, 0)}
         ),
         (
             [110, 26, (48, 3, 0, 0, 0, 1, 1, 4, 3, 0, 0, 100, 3, 232, 19, 136, 58, 152, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 4, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2, 1, 0, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)],
-            {'status':True, 'info': 'Get module FW info\nImage A Version: 0.0.1\nImage B Version: 0.0.0\nRunning Image: B; Committed Image: B\nGet module FW info time: 0.00 s\n', 'result': ('0.0.1', 0, 0, 0, '0.0.0', 1, 1, 0)}
+            {'status':True, 'info': 'Get module FW info\nImage A Version: 0.0.1\nImage B Version: 0.0.0\nRunning Image: B; Committed Image: B\n', 'result': ('0.0.1', 0, 0, 0, '0.0.0', 1, 1, 0)}
         ),
     ])
     def test_get_module_fw_info(self, mock_response, expected):
@@ -962,7 +962,7 @@ class TestCmis(object):
         assert result == expected
 
     @pytest.mark.parametrize("input_param, mock_response, expected", [
-        (1, 1,  (True, 'Module FW run: Success\nModule FW run time: 0.00 s\n')),
+        (1, 1,  (True, 'Module FW run: Success\n')),
         (1, 64,  (False, 'Module FW run: Fail\nFW_run_status 64\n')),
     ])
     def test_module_fw_run(self, input_param, mock_response, expected):
@@ -973,7 +973,7 @@ class TestCmis(object):
         assert result == expected
 
     @pytest.mark.parametrize("mock_response, expected", [
-        (1, (True, 'Module FW commit: Success\nModule FW commit time: 0.00 s\n')),
+        (1, (True, 'Module FW commit: Success\n')),
         (64, (False, 'Module FW commit: Fail\nFW_commit_status 64\n')),
     ])
     def test_module_fw_commit(self, mock_response, expected):


### PR DESCRIPTION
remove time counting message in functions because function running time could be difficult to predict in unit tests

#### Motivation and Context
It was reported the unit test results are unstable in Issue #239. It is because the function running time could be difficult to predict. Therefore, this PR is raised to resolve the instability issue. 

#### How Has This Been Tested?
I modified test_cmis.py accordingly to match the change I made in cmis.py

#### Additional Information (Optional)

