### PR TITLE
[sfp-refactor] Fix RegBitField decode/encode

### DIFF
--- a/sonic_platform_base/sonic_xcvr/fields/xcvr_field.py
+++ b/sonic_platform_base/sonic_xcvr/fields/xcvr_field.py
@@ -94,15 +94,15 @@ class RegBitField(XcvrField):
         return True
 
     def decode(self, raw_data, **decoded_deps):
-        return bool((raw_data[0] >> self.bitpos) & 1)
+        return bool((raw_data[0] >> self.bitpos % 8) & 1)
 
     def encode(self, val, raw_state=None):
         assert not self.ro and raw_state is not None
         curr_state = raw_state[0]
         if val:
-            curr_state |= (1 << self.bitpos)
+            curr_state |= (1 << self.bitpos % 8)
         else:
-            curr_state &= ~(1 << self.bitpos)
+            curr_state &= ~(1 << self.bitpos % 8)
         return bytearray([curr_state])
 
 
@@ -249,7 +249,7 @@ class RegGroupField(XcvrField):
         for field in self.fields:
             offset = field.get_offset()
             if not field.get_deps():
-                result[field.name] = field.decode(raw_data[offset - start: offset + field.get_size() - start], 
+                result[field.name] = field.decode(raw_data[offset - start: offset + field.get_size() - start],
                                               **decoded_deps)
 
         # Now decode any fields that have dependant fields in the same RegGroupField scope

--- a/tests/sonic_xcvr/test_xcvr_field.py
+++ b/tests/sonic_xcvr/test_xcvr_field.py
@@ -47,6 +47,10 @@ class MockXcvrMemMap(XcvrMemMap):
         self.NUM_REG = NumberRegField("NumReg", 100, format=">Q", size=8, ro=False)
         self.SCALE_NUM_REG = NumberRegField("ScaleNumReg", 120, format=">i", size=4, scale=100, ro=False)
         self.FIXED_NUM_REG = FixedNumberRegField("FixedNumReg", 130, 8, format=">f", size=4, ro=False)
+        self.NUM_REG_WITH_BIT = NumberRegField("NumRegWithBit", 140,
+            RegBitField("NumRegBit", bitpos=20, ro=False),
+            format="<I", size=4, ro=False
+        )
         self.STRING_REG = StringRegField("StringReg", 12, size=15)
         self.HEX_REG = HexRegField("HexReg", 30, size=3)
         self.REG_GROUP = RegGroupField("RegGroup",
@@ -167,6 +171,10 @@ class TestRegBitField(object):
 
         assert field.decode(field.encode(True, bytearray(b'\x00')))
         assert not field.decode(field.encode(False, bytearray(b'\x00')))
+
+        field = mem_map.get_field("NumRegBit")
+        assert field.decode(field.encode(True, bytearray(b'\x00')))
+        assert not field.decode(field.encode(False, bytearray(b'\xFF')))
 
 class TestRegField(object):
     def test_offset(self):


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

#### Description
<!--
     Describe your changes in detail
-->
Fix RegBitField decode/encode to handle cases where it is defined under multi-byte RegFields.

#### Motivation and Context
<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->
If defining a RegBitField in a multi-byte RegField, the specified bitpos of the RegBitField is relative to the parent RegField. However, when decoding/encoding the RegBitField, the bitpos that is used should actually be the bitpos relative to the byte that the RegBitField occupies, rather than the original specified bitpos.

#### How Has This Been Tested?
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->
Added unit test to cover this test gap. Also ran sonic-mgmt test suite on Arista platform

#### Additional Information (Optional)

