### PR TITLE
fix for firmware functions 

### DIFF
--- a/sonic_platform_base/sonic_xcvr/api/public/cmis.py
+++ b/sonic_platform_base/sonic_xcvr/api/public/cmis.py
@@ -1280,7 +1280,6 @@ class CmisApi(XcvrApi):
             else:
                 count = BLOCK_SIZE
             data = f.read(count)
-            progress = (imagesize - remaining) * 100.0 / imagesize
             if lplonly_flag:
                 fw_download_status = self.cdb.block_write_lpl(address, data)
             else:
@@ -1292,9 +1291,11 @@ class CmisApi(XcvrApi):
                 logger.info(txt)
                 return False, txt
             elapsedtime = time.time()-starttime
-            logger.info('Address: {:#08x}; Count: {}; Progress: {:.2f}%; Time: {:.2f}s'.format(address, count, progress, elapsedtime))
             address += count
             remaining -= count
+            progress = (imagesize - remaining) * 100.0 / imagesize
+            logger.info('Address: {:#08x}; Count: {}; Remain: {:#08x}; Progress: {:.2f}%; Time: {:.2f}s'.format(address, count, remaining, progress, elapsedtime))
+
         elapsedtime = time.time()-starttime
         logger.info('Total module FW download time: %.2f s' %elapsedtime)
 

--- a/sonic_platform_base/sonic_xcvr/api/public/cmisCDB.py
+++ b/sonic_platform_base/sonic_xcvr/api/public/cmisCDB.py
@@ -121,12 +121,12 @@ class CmisCdbApi(XcvrApi):
             30h-3Fh=Custom
         '''
         status = self.xcvr_eeprom.read(consts.CDB1_STATUS)
+        is_busy = bool((status >> 7) & 0x1)
         cnt = 0
         while status != 1 and cnt < MAX_WAIT:
             time.sleep(0.1)
             status = self.xcvr_eeprom.read(consts.CDB1_STATUS)
-            if status == 70:
-                break
+            is_busy = bool((status >> 7) & 0x1)
             cnt += 1
         return status
 

--- a/sonic_platform_base/sonic_xcvr/api/public/cmisCDB.py
+++ b/sonic_platform_base/sonic_xcvr/api/public/cmisCDB.py
@@ -123,7 +123,7 @@ class CmisCdbApi(XcvrApi):
         status = self.xcvr_eeprom.read(consts.CDB1_STATUS)
         is_busy = bool((status >> 7) & 0x1)
         cnt = 0
-        while status != 1 and cnt < MAX_WAIT:
+        while is_busy and cnt < MAX_WAIT:
             time.sleep(0.1)
             status = self.xcvr_eeprom.read(consts.CDB1_STATUS)
             is_busy = bool((status >> 7) & 0x1)

--- a/sonic_platform_base/sonic_xcvr/api/public/cmisCDB.py
+++ b/sonic_platform_base/sonic_xcvr/api/public/cmisCDB.py
@@ -18,7 +18,7 @@ CDB_WRITE_MSG_START = 130
 PAGE_LENGTH = 128
 INIT_OFFSET = 128
 CMDLEN = 2
-MAX_WAIT = 100
+MAX_WAIT = 600
 
 
 class CmisCdbApi(XcvrApi):
@@ -121,12 +121,12 @@ class CmisCdbApi(XcvrApi):
             30h-3Fh=Custom
         '''
         status = self.xcvr_eeprom.read(consts.CDB1_STATUS)
-        is_busy =  bool((status >> 7) & 0x1)
         cnt = 0
-        while is_busy and cnt < MAX_WAIT:
+        while status != 1 and cnt < MAX_WAIT:
             time.sleep(0.1)
             status = self.xcvr_eeprom.read(consts.CDB1_STATUS)
-            is_busy =  bool((status >> 7) & 0x1)
+            if status == 70:
+                break
             cnt += 1
         return status
 
@@ -165,7 +165,7 @@ class CmisCdbApi(XcvrApi):
             if status > 127: 
                 txt = 'Query CDB status: Busy'
             else:
-                status_txt = self.failed_status_dict[status & 0x3f]
+                status_txt = self.failed_status_dict.get(status & 0x3f, "Unknown")
                 txt = 'Query CDB status: Fail- ' + status_txt
         else:
             txt = 'Query CDB status: Success'
@@ -189,7 +189,7 @@ class CmisCdbApi(XcvrApi):
             if status > 127: 
                 txt = 'Enter password status: Busy'
             else:
-                status_txt = self.failed_status_dict[status & 0x3f]
+                status_txt = self.failed_status_dict.get(status & 0x3f, "Unknown")
                 txt = 'Enter password status: Fail- ' + status_txt
         else:
             txt = 'Enter password status: Success'
@@ -209,7 +209,7 @@ class CmisCdbApi(XcvrApi):
             if status > 127: 
                 txt = 'Get module feature status: Busy'
             else:
-                status_txt = self.failed_status_dict[status & 0x3f]
+                status_txt = self.failed_status_dict.get(status & 0x3f, "Unknown")
                 txt = 'Get module feature status: Fail- ' + status_txt
         else:
             txt = 'Get module feature status: Success'
@@ -230,7 +230,7 @@ class CmisCdbApi(XcvrApi):
             if status > 127: 
                 txt = 'Get firmware management feature status: Busy'
             else:
-                status_txt = self.failed_status_dict[status & 0x3f]
+                status_txt = self.failed_status_dict.get(status & 0x3f, "Unknown")
                 txt = 'Get firmware management feature status: Fail- ' + status_txt
         else:
             txt = 'Get firmware management feature status: Success'
@@ -253,7 +253,7 @@ class CmisCdbApi(XcvrApi):
             if status > 127: 
                 txt = 'Get firmware info status: Busy'
             else:
-                status_txt = self.failed_status_dict[status & 0x3f]
+                status_txt = self.failed_status_dict.get(status & 0x3f, "Unknown")
                 txt = 'Get firmware info status: Fail- ' + status_txt
         else:
             txt = 'Get firmware info status: Success'
@@ -284,7 +284,7 @@ class CmisCdbApi(XcvrApi):
             if status > 127: 
                 txt = 'Start firmware download status: Busy'
             else:
-                status_txt = self.failed_status_dict[status & 0x3f]
+                status_txt = self.failed_status_dict.get(status & 0x3f, "Unknown")
                 txt = 'Start firmware download status: Fail- ' + status_txt
         else:
             txt = 'Start firmware download status: Success'
@@ -307,7 +307,7 @@ class CmisCdbApi(XcvrApi):
             if status > 127: 
                 txt = 'Abort firmware download status: Busy'
             else:
-                status_txt = self.failed_status_dict[status & 0x3f]
+                status_txt = self.failed_status_dict.get(status & 0x3f, "Unknown")
                 txt = 'Abort firmware download status: Fail- ' + status_txt
         else:
             txt = 'Abort firmware download status: Success'
@@ -333,13 +333,12 @@ class CmisCdbApi(XcvrApi):
         cmd += paddedPayload
         cmd[133-INIT_OFFSET] = self.cdb_chkcode(cmd)
         self.write_cdb(cmd)
-        time.sleep(0.2)
         status = self.cdb1_chkstatus()
         if (status != 0x1):
             if status > 127: 
                 txt = 'LPL firmware download status: Busy'
             else:
-                status_txt = self.failed_status_dict[status & 0x3f]
+                status_txt = self.failed_status_dict.get(status & 0x3f, "Unknown")
                 txt = 'LPL firmware download status: Fail- ' + status_txt
         else:
             txt = 'LPL firmware download status: Success'
@@ -386,13 +385,12 @@ class CmisCdbApi(XcvrApi):
         cmd += addr_byte
         cmd[133-INIT_OFFSET] = self.cdb_chkcode(cmd)
         self.write_cdb(cmd)
-        time.sleep(0.2)
         status = self.cdb1_chkstatus()
         if (status != 0x1):
             if status > 127: 
                 txt = 'EPL firmware download status: Busy'
             else:
-                status_txt = self.failed_status_dict[status & 0x3f]
+                status_txt = self.failed_status_dict.get(status & 0x3f, "Unknown")
                 txt = 'EPL firmware download status: Fail- ' + status_txt
         else:
             txt = 'EPL firmware download status: Success'
@@ -414,7 +412,7 @@ class CmisCdbApi(XcvrApi):
             if status > 127: 
                 txt = 'Firmware download complete status: Busy'
             else:
-                status_txt = self.failed_status_dict[status & 0x3f]
+                status_txt = self.failed_status_dict.get(status & 0x3f, "Unknown")
                 txt = 'Firmware download complete status: Fail- ' + status_txt
         else:
             txt = 'Firmware download complete status: Success'
@@ -442,7 +440,7 @@ class CmisCdbApi(XcvrApi):
             if status > 127: 
                 txt = 'Run firmware status: Busy'
             else:
-                status_txt = self.failed_status_dict[status & 0x3f]
+                status_txt = self.failed_status_dict.get(status & 0x3f, "Unknown")
                 txt = 'Run firmware status: Fail- ' + status_txt
         else:
             txt = 'Run firmware status: Success'
@@ -472,7 +470,7 @@ class CmisCdbApi(XcvrApi):
             if status > 127: 
                 txt = 'Commit firmware status: Busy'
             else:
-                status_txt = self.failed_status_dict[status & 0x3f]
+                status_txt = self.failed_status_dict.get(status & 0x3f, "Unknown")
                 txt = 'Commit firmware status: Fail- ' + status_txt
         else:
             txt = 'Commit firmware status: Success'


### PR DESCRIPTION
This PR aims to fix firmware related functions

#### Description
1. report updated address, count and remaining bytes info in module_fw_download() 
2. remove additional 200 ms wait time in block_write_lpl() and block_write_epl() 
3. increase max wait time to 1 min in cdb1_chkstatus() if status is not 1. If status is password error (70) it will break the wait loop. 
4. add protection to failed_status_dict

#### Motivation and Context
This PR aims to resolve failures due to not enough wait time. It moves all the wait to CDB status check. When status = 1 , it means success and should not wait any longer. Therefore I remove 200 ms wait time in  block_write_lpl() and block_write_epl().

It also adds extra protection when status is not defined in the failed_status_dict.

#### How Has This Been Tested?
Test functions are unchanged. 

#### Additional Information (Optional)

