### PR TITLE
Firmware upgrade CLI support for QSFP-DD transceivers

### DIFF
--- a/sonic_platform_base/sonic_xcvr/api/public/cmis.py
+++ b/sonic_platform_base/sonic_xcvr/api/public/cmis.py
@@ -687,7 +687,7 @@ class CmisApi(XcvrApi):
         This function returns the application select code that each host lane has
         '''
         if (self.is_flat_memory()):
-            return 'N/A'
+            return {'{}{}'.format(consts.ACTIVE_APSEL_HOSTLANE, i) : 'N/A' for i in range(1, self.NUM_CHANNELS+1)}
         return self.xcvr_eeprom.read(consts.ACTIVE_APSEL_CODE)
 
     def get_tx_config_power(self):
@@ -762,7 +762,7 @@ class CmisApi(XcvrApi):
             'low warn' : 'N/A'
         }
 
-        if (self.is_flat_memory()):
+        if self.is_flat_memory():
             return laser_temp_dict
 
         try:

--- a/sonic_platform_base/sonic_xcvr/api/public/cmisCDB.py
+++ b/sonic_platform_base/sonic_xcvr/api/public/cmisCDB.py
@@ -27,7 +27,7 @@ class CmisCdbApi(XcvrApi):
         self.cdb_instance_supported = self.xcvr_eeprom.read(consts.CDB_SUPPORT)
         self.failed_status_dict = self.xcvr_eeprom.mem_map.codes.CDB_FAIL_STATUS
         assert self.cdb_instance_supported != 0
-    
+
     def cdb1_chkflags(self):
         '''
         This function detects if there is datapath or module firmware fault.
@@ -64,14 +64,14 @@ class CmisCdbApi(XcvrApi):
             return False
         else:
             return True
-    
+
     def cdb_chkcode(self, cmd):
         '''
         This function calculates and returns the checksum of a CDB command
         '''
         checksum = 0
         for byte in cmd:
-            checksum += byte   
+            checksum += byte
         return 0xff - (checksum & 0xff)
 
     def cdb1_chkstatus(self):
@@ -140,7 +140,7 @@ class CmisCdbApi(XcvrApi):
     def read_cdb(self):
         '''
         This function reads the reply of a CDB command from page 0x9f.
-        It returns the reply message of a CDB command. 
+        It returns the reply message of a CDB command.
         rpllen is the length (number of bytes) of rpl
         rpl_chkcode is the check code of rpl and can be calculated by cdb_chkcode()
         rpl is the reply message.
@@ -162,7 +162,7 @@ class CmisCdbApi(XcvrApi):
         self.write_cdb(cmd)
         status = self.cdb1_chkstatus()
         if (status != 0x1):
-            if status > 127: 
+            if status > 127:
                 txt = 'Query CDB status: Busy'
             else:
                 status_txt = self.failed_status_dict.get(status & 0x3f, "Unknown")
@@ -186,7 +186,7 @@ class CmisCdbApi(XcvrApi):
         self.write_cdb(cmd)
         status = self.cdb1_chkstatus()
         if (status != 0x1):
-            if status > 127: 
+            if status > 127:
                 txt = 'Enter password status: Busy'
             else:
                 status_txt = self.failed_status_dict.get(status & 0x3f, "Unknown")
@@ -206,7 +206,7 @@ class CmisCdbApi(XcvrApi):
         self.write_cdb(cmd)
         status = self.cdb1_chkstatus()
         if (status != 0x1):
-            if status > 127: 
+            if status > 127:
                 txt = 'Get module feature status: Busy'
             else:
                 status_txt = self.failed_status_dict.get(status & 0x3f, "Unknown")
@@ -227,7 +227,7 @@ class CmisCdbApi(XcvrApi):
         self.write_cdb(cmd)
         status = self.cdb1_chkstatus()
         if (status != 0x1):
-            if status > 127: 
+            if status > 127:
                 txt = 'Get firmware management feature status: Busy'
             else:
                 status_txt = self.failed_status_dict.get(status & 0x3f, "Unknown")
@@ -240,17 +240,16 @@ class CmisCdbApi(XcvrApi):
     # Get FW info
     def get_fw_info(self):
         '''
-        This command returns the firmware versions and firmware default running 
+        This command returns the firmware versions and firmware default running
         images that reside in the module
         It returns the reply message of this CDB command 0100h.
         '''
-        # self.module_enter_password(0x00000000)
         cmd = bytearray(b'\x01\x00\x00\x00\x00\x00\x00\x00')
         cmd[133-INIT_OFFSET] = self.cdb_chkcode(cmd)
         self.write_cdb(cmd)
         status = self.cdb1_chkstatus()
         if (status != 0x1):
-            if status > 127: 
+            if status > 127:
                 txt = 'Get firmware info status: Busy'
             else:
                 status_txt = self.failed_status_dict.get(status & 0x3f, "Unknown")
@@ -281,7 +280,7 @@ class CmisCdbApi(XcvrApi):
         time.sleep(2)
         status = self.cdb1_chkstatus()
         if (status != 0x1):
-            if status > 127: 
+            if status > 127:
                 txt = 'Start firmware download status: Busy'
             else:
                 status_txt = self.failed_status_dict.get(status & 0x3f, "Unknown")
@@ -304,7 +303,7 @@ class CmisCdbApi(XcvrApi):
         self.write_cdb(cmd)
         status = self.cdb1_chkstatus()
         if (status != 0x1):
-            if status > 127: 
+            if status > 127:
                 txt = 'Abort firmware download status: Busy'
             else:
                 status_txt = self.failed_status_dict.get(status & 0x3f, "Unknown")
@@ -320,7 +319,7 @@ class CmisCdbApi(XcvrApi):
         This command writes one block of the firmware image into the LPL
         It returns the status of CDB command 0103h
         '''
-        # lpl_len includes 136-139, four bytes, data is 116-byte long. 
+        # lpl_len includes 136-139, four bytes, data is 116-byte long.
         lpl_len = len(data) + 4
         cmd = bytearray(b'\x01\x03\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00')
         cmd[132-INIT_OFFSET] = lpl_len & 0xff
@@ -335,7 +334,7 @@ class CmisCdbApi(XcvrApi):
         self.write_cdb(cmd)
         status = self.cdb1_chkstatus()
         if (status != 0x1):
-            if status > 127: 
+            if status > 127:
                 txt = 'LPL firmware download status: Busy'
             else:
                 status_txt = self.failed_status_dict.get(status & 0x3f, "Unknown")
@@ -387,7 +386,7 @@ class CmisCdbApi(XcvrApi):
         self.write_cdb(cmd)
         status = self.cdb1_chkstatus()
         if (status != 0x1):
-            if status > 127: 
+            if status > 127:
                 txt = 'EPL firmware download status: Busy'
             else:
                 status_txt = self.failed_status_dict.get(status & 0x3f, "Unknown")
@@ -409,7 +408,7 @@ class CmisCdbApi(XcvrApi):
         self.write_cdb(cmd)
         status = self.cdb1_chkstatus()
         if (status != 0x1):
-            if status > 127: 
+            if status > 127:
                 txt = 'Firmware download complete status: Busy'
             else:
                 status_txt = self.failed_status_dict.get(status & 0x3f, "Unknown")
@@ -437,7 +436,7 @@ class CmisCdbApi(XcvrApi):
         self.write_cdb(cmd)
         status = self.cdb1_chkstatus()
         if (status != 0x1):
-            if status > 127: 
+            if status > 127:
                 txt = 'Run firmware status: Busy'
             else:
                 status_txt = self.failed_status_dict.get(status & 0x3f, "Unknown")
@@ -467,7 +466,7 @@ class CmisCdbApi(XcvrApi):
         self.write_cdb(cmd)
         status = self.cdb1_chkstatus()
         if (status != 0x1):
-            if status > 127: 
+            if status > 127:
                 txt = 'Commit firmware status: Busy'
             else:
                 status_txt = self.failed_status_dict.get(status & 0x3f, "Unknown")

--- a/sonic_platform_base/sonic_xcvr/sfp_optoe_base.py
+++ b/sonic_platform_base/sonic_xcvr/sfp_optoe_base.py
@@ -139,12 +139,21 @@ class SfpOptoeBase(SfpBase):
 
     def set_lpmode(self, lpmode):
         """
-        This common API is applicable only for CMIS as Low Power mode can be controlled 
+        This common API is applicable only for CMIS as Low Power mode can be controlled
         via EEPROM registers.For other media types like QSFP28/QSFP+ etc., platform
         vendors has to implement accordingly.
         """
         api = self.get_xcvr_api()
         return api.set_lp_mode(lpmode) if api is not None else None
+
+    def set_optoe_write_max(self, write_max):
+        sys_path = self.get_eeprom_path()
+        sys_path = sys_path.replace("eeprom", "write_max")
+        try:
+            with open(sys_path, mode='w') as f:
+                f.write(str(write_max))
+        except (OSError, IOError):
+            pass
 
     def read_eeprom(self, offset, num_bytes):
         try:

--- a/tests/sonic_xcvr/test_cmis.py
+++ b/tests/sonic_xcvr/test_cmis.py
@@ -810,12 +810,6 @@ class TestCmis(object):
         self.api.get_loopback_capability.return_value = mock_response
         self.api.set_loopback_mode(input_param)
 
-    def test_get_cdb_api(self):
-        self.api.get_cdb_api()
-
-    def test_get_vdm_api(self):
-        self.api.get_vdm_api()
-
     @pytest.mark.parametrize("mock_response, expected",[
         (
             {'Pre-FEC BER Average Media Input': {1: [0.001, 0.0125, 0, 0.01, 0, False, False, False, False]}},
@@ -886,50 +880,6 @@ class TestCmis(object):
         result = self.api.get_module_level_flag()
         assert result == expected
 
-    @pytest.mark.parametrize("input_param, mock_response1, mock_response2, expected", [
-        (
-            False,
-            [0x77, 0xff],
-            [18, 35, (0, 7, 112, 255, 255, 16, 0, 0, 19, 136, 0, 100, 3, 232, 19, 136, 58, 152)],
-            {'status':True, 'info': 'Auto page support: True\nMax write length: 2048\nStart payload size 112\nMax block size 2048\nWrite to EPL supported\nAbort CMD102h supported True\n', 'result': (112, 2048, False, True, 2048)}
-        ),
-        (
-            False,
-            [0x77, 0xff],
-            [18, 35, (0, 7, 112, 255, 255, 1, 0, 0, 19, 136, 0, 100, 3, 232, 19, 136, 58, 152)],
-            {'status':True, 'info': 'Auto page support: True\nMax write length: 2048\nStart payload size 112\nMax block size 2048\nWrite to LPL supported\nAbort CMD102h supported True\n', 'result': (112, 2048, True, True, 2048)}
-        ),
-    ])
-    def test_get_module_fw_upgrade_feature(self, input_param, mock_response1, mock_response2, expected):
-        self.api.xcvr_eeprom.read = MagicMock()
-        self.api.xcvr_eeprom.read.side_effect = mock_response1
-        self.api.cdb = MagicMock()
-        self.api.cdb.get_fw_management_features = MagicMock()
-        self.api.cdb.get_fw_management_features.return_value = mock_response2
-        self.api.cdb.cdb_chkcode = MagicMock()
-        self.api.cdb.cdb_chkcode.return_value = mock_response2[1]
-        result = self.api.get_module_fw_upgrade_feature(input_param)
-        assert result == expected
-
-    @pytest.mark.parametrize("mock_response, expected", [
-        (
-            [110, 26, (3, 3, 0, 0, 0, 1, 1, 4, 3, 0, 0, 100, 3, 232, 19, 136, 58, 152, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 4, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2, 1, 0, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)],
-            {'status':True, 'info': 'Get module FW info\nImage A Version: 0.0.1\nImage B Version: 0.0.0\nRunning Image: A; Committed Image: A\n', 'result': ('0.0.1', 1, 1, 0, '0.0.0', 0, 0, 0)}
-        ),
-        (
-            [110, 26, (48, 3, 0, 0, 0, 1, 1, 4, 3, 0, 0, 100, 3, 232, 19, 136, 58, 152, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 4, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2, 1, 0, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)],
-            {'status':True, 'info': 'Get module FW info\nImage A Version: 0.0.1\nImage B Version: 0.0.0\nRunning Image: B; Committed Image: B\n', 'result': ('0.0.1', 0, 0, 0, '0.0.0', 1, 1, 0)}
-        ),
-    ])
-    def test_get_module_fw_info(self, mock_response, expected):
-        self.api.cdb = MagicMock()
-        self.api.cdb.get_fw_info = MagicMock()
-        self.api.cdb.get_fw_info.return_value = mock_response
-        self.api.cdb.cdb_chkcode = MagicMock()
-        self.api.cdb.cdb_chkcode.return_value = mock_response[1]
-        result = self.api.get_module_fw_info()
-        assert result == expected
-
     @pytest.mark.parametrize("input_param, mock_response, expected", [
         (1, 1,  (True, 'Module FW run: Success\n')),
         (1, 64,  (False, 'Module FW run: Fail\nFW_run_status 64\n')),
@@ -977,8 +927,8 @@ class TestCmis(object):
     def test_module_fw_upgrade(self, input_param, mock_response, expected):
         self.api.get_module_fw_info = MagicMock()
         self.api.get_module_fw_info.return_value = mock_response[0]
-        self.api.get_module_fw_upgrade_feature = MagicMock()
-        self.api.get_module_fw_upgrade_feature.return_value = mock_response[1]
+        self.api.get_module_fw_mgmt_feature = MagicMock()
+        self.api.get_module_fw_mgmt_feature.return_value = mock_response[1]
         self.api.module_fw_download = MagicMock()
         self.api.module_fw_download.return_value = mock_response[2]
         self.api.module_fw_switch = MagicMock()


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

#### Description
Changes to support firmware upgrade CLI for QSFP-DD transceivers

#### Motivation and Context
1. Refactored some of the APIs so as to show firmware download/upgrade progress
2. Fixed few crashes

#### How Has This Been Tested?
1. Ran unit test
2. Firmware upgrade done successfully on Inphi, Molex and Centera QSFP-DD modules

#### Additional Information (Optional)

