### PR TITLE
[sfp-refactor] Fix RegGroupField decode

### DIFF
--- a/sonic_platform_base/sonic_xcvr/fields/xcvr_field.py
+++ b/sonic_platform_base/sonic_xcvr/fields/xcvr_field.py
@@ -257,7 +257,7 @@ class RegGroupField(XcvrField):
             offset = field.get_offset()
             deps = field.get_deps()
             if deps:
-                decoded_deps = {dep: result[dep] for dep in deps}
+                decoded_deps.update({dep: result[dep] for dep in deps if dep in result})
                 result[field.name] = field.decode(raw_data[offset - start: offset + field.get_size() - start],
                                                 **decoded_deps)
         return result


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

#### Description
<!--
     Describe your changes in detail
-->
Fix RegGroupField decode to handle dependent fields which are not defined in the same RegGroupField scope

#### Motivation and Context
<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->
If a field inside a RegGroupField has a dep field that is defined outside of the RegGroupField then the decode() will fail.

#### How Has This Been Tested?
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->
Tested on Arista platform with SFF-8472 compliant xcvrs (8472 memory map has fields defined which run into this case)

#### Additional Information (Optional)

