### PR TITLE
Add CMIS QSFP support

### DIFF
--- a/sonic_platform_base/sonic_xcvr/codes/public/sff8024.py
+++ b/sonic_platform_base/sonic_xcvr/codes/public/sff8024.py
@@ -72,7 +72,7 @@ class Sff8024(XcvrCodes):
         27: 'DSFP',
         28: 'Link-x4',
         29: 'Link-x8',
-        30: 'QSFP+'
+        30: 'QSFP+C'
     }
 
     CONNECTORS = {

--- a/sonic_platform_base/sonic_xcvr/xcvr_api_factory.py
+++ b/sonic_platform_base/sonic_xcvr/xcvr_api_factory.py
@@ -40,7 +40,7 @@ class XcvrApiFactory(object):
         # TODO: load correct classes from id_mapping file
         id = self._get_id()
         # QSFP-DD or OSFP
-        if id == 0x18 or id == 0x19:
+        if id == 0x18 or id == 0x19 or id == 0x1e:
             codes = CmisCodes
             mem_map = CmisMemMap(codes)
             xcvr_eeprom = XcvrEeprom(self.reader, self.writer, mem_map)


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

#### Description
<!--
     Describe your changes in detail
-->
Add support for CMIS-compliant QSFP xcvrs (identifer 1Eh)

#### Motivation and Context
<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->
QSFP xcvrs which comply to CMIS have a different id and are not currently supported by the new design

#### How Has This Been Tested?
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->
Ran tests/sonic_xcvr/
Tested on Arista platform with these xcvrs

#### Additional Information (Optional)

