### PR TITLE
SFP-Refactor: bug fixes

### DIFF
--- a/sonic_platform_base/sonic_xcvr/api/public/cmis.py
+++ b/sonic_platform_base/sonic_xcvr/api/public/cmis.py
@@ -130,7 +130,7 @@ class CmisApi(XcvrApi):
             "ext_identifier": "%s (%sW Max)" % (power_class, max_power),
             "ext_rateselect_compliance": "N/A", # Not supported
             "cable_type": "Length Cable Assembly(m)",
-            "cable_length": admin_info[consts.LENGTH_ASSEMBLY_FIELD],
+            "cable_length": float(admin_info[consts.LENGTH_ASSEMBLY_FIELD]),
             "nominal_bit_rate": 0, # Not supported
             "specification_compliance": admin_info[consts.MEDIA_TYPE_FIELD],
             "vendor_date": admin_info[consts.VENDOR_DATE_FIELD],
@@ -610,8 +610,6 @@ class CmisApi(XcvrApi):
         '''
         This function returns module media type: MMF, SMF, Passive Copper Cable, Active Cable Assembly or Base-T.
         '''
-        if self.is_flat_memory():
-            return 'N/A'
         return self.xcvr_eeprom.read(consts.MEDIA_TYPE_FIELD)
 
     def get_host_electrical_interface(self):
@@ -624,19 +622,16 @@ class CmisApi(XcvrApi):
         '''
         This function returns module media electrical interface. Table 4-6 ~ 4-10 in SFF-8024 Rev4.6
         '''
-        if self.is_flat_memory():
-            return 'N/A'
-
         media_type = self.get_module_media_type()
-        if media_type == 'Multimode Fiber (MMF)':
+        if media_type == 'nm_850_media_interface':
             return self.xcvr_eeprom.read(consts.MODULE_MEDIA_INTERFACE_850NM)
-        elif media_type == 'Single Mode Fiber (SMF)':
+        elif media_type == 'sm_media_interface':
             return self.xcvr_eeprom.read(consts.MODULE_MEDIA_INTERFACE_SM)
-        elif media_type == 'Passive Copper Cable':
+        elif media_type == 'passive_copper_media_interface':
             return self.xcvr_eeprom.read(consts.MODULE_MEDIA_INTERFACE_PASSIVE_COPPER)
-        elif media_type == 'Active Cable Assembly':
+        elif media_type == 'active_cable_media_interface':
             return self.xcvr_eeprom.read(consts.MODULE_MEDIA_INTERFACE_ACTIVE_CABLE)
-        elif media_type == 'BASE-T':
+        elif media_type == 'base_t_media_interface':
             return self.xcvr_eeprom.read(consts.MODULE_MEDIA_INTERFACE_BASE_T)
         else:
             return 'Unknown media interface'

--- a/sonic_platform_base/sonic_xcvr/codes/public/cmis.py
+++ b/sonic_platform_base/sonic_xcvr/codes/public/cmis.py
@@ -12,15 +12,6 @@ class CmisCodes(Sff8024):
         7: "Power Class 8"
     }
 
-    MEDIA_TYPES = {
-        0: "Undefined",
-        1: "nm_850_media_interface",
-        2: "sm_media_interface",
-        3: "passive_copper_media_interface",
-        4: "active_cable_media_interface",
-        5: "base_t_media_interface",
-    }
-
     MEDIA_INTERFACE_TECH = {
         0: '850 nm VCSEL',
         1: '1310 nm VCSEL',

--- a/sonic_platform_base/sonic_xcvr/codes/public/sff8024.py
+++ b/sonic_platform_base/sonic_xcvr/codes/public/sff8024.py
@@ -175,12 +175,12 @@ class Sff8024(XcvrCodes):
     }
 
     MODULE_MEDIA_TYPE = {
-        0: "Undefined",
-        1: "nm_850_media_interface",
-        2: "sm_media_interface",
-        3: "passive_copper_media_interface",
-        4: "active_cable_media_interface",
-        5: "base_t_media_interface",
+        0: 'Undefined',
+        1: 'nm_850_media_interface',
+        2: 'sm_media_interface',
+        3: 'passive_copper_media_interface',
+        4: 'active_cable_media_interface',
+        5: 'base_t_media_interface'
     }
 
     HOST_ELECTRICAL_INTERFACE = {

--- a/sonic_platform_base/sonic_xcvr/codes/public/sff8024.py
+++ b/sonic_platform_base/sonic_xcvr/codes/public/sff8024.py
@@ -174,14 +174,13 @@ class Sff8024(XcvrCodes):
         129: 'Capable of 128GFC'
     }
 
-
     MODULE_MEDIA_TYPE = {
-        0: 'Undefined',
-        1: 'Multimode Fiber (MMF)',
-        2: 'Single Mode Fiber (SMF)',
-        3: 'Passive Copper Cable',
-        4: 'Active Cable Assembly',
-        5: 'BASE-T'
+        0: "Undefined",
+        1: "nm_850_media_interface",
+        2: "sm_media_interface",
+        3: "passive_copper_media_interface",
+        4: "active_cable_media_interface",
+        5: "base_t_media_interface",
     }
 
     HOST_ELECTRICAL_INTERFACE = {

--- a/sonic_platform_base/sonic_xcvr/mem_maps/public/cmis.py
+++ b/sonic_platform_base/sonic_xcvr/mem_maps/public/cmis.py
@@ -52,7 +52,7 @@ class CmisMemMap(XcvrMemMap):
 
             CodeRegField(consts.CONNECTOR_FIELD, self.getaddr(0x0, 203), self.codes.CONNECTORS),
             CodeRegField(consts.HOST_ELECTRICAL_INTERFACE, self.getaddr(0x0, 86), self.codes.HOST_ELECTRICAL_INTERFACE),
-            CodeRegField(consts.MEDIA_TYPE_FIELD, self.getaddr(0x0, 85), self.codes.MODULE_MEDIA_TYPE),
+            CodeRegField(consts.MEDIA_TYPE_FIELD, self.getaddr(0x0, 85), self.codes.MEDIA_TYPES),
             CodeRegField(consts.MODULE_MEDIA_INTERFACE_850NM, self.getaddr(0x0, 87), self.codes.NM_850_MEDIA_INTERFACE),
             CodeRegField(consts.MODULE_MEDIA_INTERFACE_SM, self.getaddr(0x0, 87), self.codes.SM_MEDIA_INTERFACE),
             CodeRegField(consts.MODULE_MEDIA_INTERFACE_PASSIVE_COPPER, self.getaddr(0x0, 87), self.codes.PASSIVE_COPPER_MEDIA_INTERFACE),

--- a/sonic_platform_base/sonic_xcvr/mem_maps/public/cmis.py
+++ b/sonic_platform_base/sonic_xcvr/mem_maps/public/cmis.py
@@ -52,7 +52,7 @@ class CmisMemMap(XcvrMemMap):
 
             CodeRegField(consts.CONNECTOR_FIELD, self.getaddr(0x0, 203), self.codes.CONNECTORS),
             CodeRegField(consts.HOST_ELECTRICAL_INTERFACE, self.getaddr(0x0, 86), self.codes.HOST_ELECTRICAL_INTERFACE),
-            CodeRegField(consts.MEDIA_TYPE_FIELD, self.getaddr(0x0, 85), self.codes.MEDIA_TYPES),
+            CodeRegField(consts.MEDIA_TYPE_FIELD, self.getaddr(0x0, 85), self.codes.MODULE_MEDIA_TYPE),
             CodeRegField(consts.MODULE_MEDIA_INTERFACE_850NM, self.getaddr(0x0, 87), self.codes.NM_850_MEDIA_INTERFACE),
             CodeRegField(consts.MODULE_MEDIA_INTERFACE_SM, self.getaddr(0x0, 87), self.codes.SM_MEDIA_INTERFACE),
             CodeRegField(consts.MODULE_MEDIA_INTERFACE_PASSIVE_COPPER, self.getaddr(0x0, 87), self.codes.PASSIVE_COPPER_MEDIA_INTERFACE),

--- a/tests/sonic_xcvr/test_cmis.py
+++ b/tests/sonic_xcvr/test_cmis.py
@@ -498,7 +498,7 @@ class TestCmis(object):
         assert result == False
 
     @pytest.mark.parametrize("mock_response, expected", [
-        ("Single Mode Fiber (SMF)", "Single Mode Fiber (SMF)")
+        ("sm_media_interface", "sm_media_interface")
     ])
     def test_get_module_media_type(self, mock_response, expected):
         self.api.xcvr_eeprom.read = MagicMock()
@@ -516,11 +516,11 @@ class TestCmis(object):
         assert result == expected
 
     @pytest.mark.parametrize("mock_response1, mock_response2, expected", [
-            ("Single Mode Fiber (SMF)", "400ZR", "400ZR"),
-            ("Multimode Fiber (MMF)", "100GE BiDi", "100GE BiDi"),
-            ("Passive Copper Cable", "Copper cable", "Copper cable"),
-            ("Active Cable Assembly", "Active Loopback module", "Active Loopback module"),
-            ("BASE-T", "1000BASE-T (Clause 40)", "1000BASE-T (Clause 40)"),
+            ("sm_media_interface", "400ZR", "400ZR"),
+            ("nm_850_media_interface", "100GE BiDi", "100GE BiDi"),
+            ("passive_copper_media_interface", "Copper cable", "Copper cable"),
+            ("active_cable_media_interface", "Active Loopback module", "Active Loopback module"),
+            ("base_t_media_interface", "1000BASE-T (Clause 40)", "1000BASE-T (Clause 40)"),
             ("ABCD", "ABCD", "Unknown media interface")
     ])
     def test_get_module_media_interface(self, mock_response1, mock_response2, expected):
@@ -951,7 +951,7 @@ class TestCmis(object):
                     'VendorPN': 'ABCD',
                     'Connector': 'LC',
                     'Length Cable Assembly': 0.0,
-                    'ModuleMediaType': 'Single Mode Fiber (SMF)',
+                    'ModuleMediaType': 'sm_media_interface',
                     'VendorDate': '21010100',
                     'VendorOUI': 'xx-xx-xx'
                 },
@@ -965,7 +965,7 @@ class TestCmis(object):
                 '5.0',
                 '0.1',
                 '0.0',
-                'Single Mode Fiber (SMF)'
+                'sm_media_interface'
             ],
             {   'type': 'QSFP-DD Double Density 8X Pluggable Transceiver',
                 'type_abbrv_name': 'QSFP-DD',
@@ -976,7 +976,7 @@ class TestCmis(object):
                 'cable_type': 'Length Cable Assembly(m)',
                 'cable_length': 0.0,
                 'nominal_bit_rate': 0,
-                'specification_compliance': 'Single Mode Fiber (SMF)',
+                'specification_compliance': 'sm_media_interface',
                 'application_advertisement': 'N/A',
                 'active_firmware': '0.1',
                 'media_lane_count': 1,


### PR DESCRIPTION
#### Description
Fix bugs in SFP refactor.

#### Motivation and Context
When comparing non-sfp refactor with SFP refactor, some fields are not properly displayed.
CMIS pre-emphasis settings is broken in DellEMC Z9332f due to SFP refactor.
#### How Has This Been Tested?
Tested in DellEMC Z9332f platform.
[sfp_UT.txt](https://github.com/Azure/sonic-platform-common/files/7625294/sfp_UT.txt)
[z9332f_preemp.txt](https://github.com/Azure/sonic-platform-common/files/7639646/z9332f_preemp.txt)

#### Additional Information (Optional)


