### PR TITLE
[SFP-Refactor]Fix vendor revision key issue

### DIFF
--- a/sonic_platform_base/sfp_base.py
+++ b/sonic_platform_base/sfp_base.py
@@ -111,6 +111,7 @@ class SfpBase(device_base.DeviceBase):
         type                       |1*255VCHAR     |type of SFP
         type_abbrv_name            |1*255VCHAR     |type of SFP, abbreviated
         hardware_rev               |1*255VCHAR     |hardware version of SFP
+        vendor_rev                 |1*255VCHAR     |vendor revision of SFP
         serial                     |1*255VCHAR     |serial number of the SFP
         manufacturer               |1*255VCHAR     |SFP vendor name
         model                      |1*255VCHAR     |SFP model name

--- a/sonic_platform_base/sonic_xcvr/api/public/sff8436.py
+++ b/sonic_platform_base/sonic_xcvr/api/public/sff8436.py
@@ -48,7 +48,7 @@ class Sff8436Api(XcvrApi):
         xcvr_info = {
             "type": serial_id[consts.ID_FIELD],
             "type_abbrv_name": serial_id[consts.ID_ABBRV_FIELD],
-            "hardware_rev": serial_id[consts.VENDOR_REV_FIELD],
+            "vendor_rev": serial_id[consts.VENDOR_REV_FIELD],
             "serial": serial_id[consts.VENDOR_SERIAL_NO_FIELD],
             "manufacturer": serial_id[consts.VENDOR_NAME_FIELD],
             "model": serial_id[consts.VENDOR_PART_NO_FIELD],

--- a/sonic_platform_base/sonic_xcvr/api/public/sff8472.py
+++ b/sonic_platform_base/sonic_xcvr/api/public/sff8472.py
@@ -41,7 +41,7 @@ class Sff8472Api(XcvrApi):
         xcvr_info = {
             "type": serial_id[consts.ID_FIELD],
             "type_abbrv_name": serial_id[consts.ID_ABBRV_FIELD],
-            "hardware_rev": serial_id[consts.VENDOR_REV_FIELD],
+            "vendor_rev": serial_id[consts.VENDOR_REV_FIELD],
             "serial": serial_id[consts.VENDOR_SERIAL_NO_FIELD],
             "manufacturer": serial_id[consts.VENDOR_NAME_FIELD],
             "model": serial_id[consts.VENDOR_PART_NO_FIELD],

--- a/sonic_platform_base/sonic_xcvr/api/public/sff8636.py
+++ b/sonic_platform_base/sonic_xcvr/api/public/sff8636.py
@@ -55,7 +55,7 @@ class Sff8636Api(XcvrApi):
         xcvr_info = {
             "type": serial_id[consts.ID_FIELD],
             "type_abbrv_name": serial_id[consts.ID_ABBRV_FIELD],
-            "hardware_rev": serial_id[consts.VENDOR_REV_FIELD],
+            "vendor_rev": serial_id[consts.VENDOR_REV_FIELD],
             "serial": serial_id[consts.VENDOR_SERIAL_NO_FIELD],
             "manufacturer": serial_id[consts.VENDOR_NAME_FIELD],
             "model": serial_id[consts.VENDOR_PART_NO_FIELD],


### PR DESCRIPTION
#### Description
sfputil show eeprom CLI crashes as "vendor_rev" key is not available in sff8436/8636.
#### Motivation and Context
hardware_rev key is used in place of vendor_rev and it causes the crash.
#### How Has This Been Tested?
Verified in DellEMC Z9332f platform.
#### Additional Information (Optional)

**Before fix:**
sfputil show eeprom -p Ethernet80
  Traceback (most recent call last):
    File "/usr/local/bin/sfputil", line 8, in <module>
      sys.exit(cli())
    File "/usr/local/lib/python3.9/dist-packages/click/core.py", line 764, in __call__
      return self.main(*args, **kwargs)
    File "/usr/local/lib/python3.9/dist-packages/click/core.py", line 717, in main
      rv = self.invoke(ctx)
    File "/usr/local/lib/python3.9/dist-packages/click/core.py", line 1137, in invoke
      return _process_result(sub_ctx.command.invoke(sub_ctx))
    File "/usr/local/lib/python3.9/dist-packages/click/core.py", line 1137, in invoke
      return _process_result(sub_ctx.command.invoke(sub_ctx))
    File "/usr/local/lib/python3.9/dist-packages/click/core.py", line 956, in invoke
      return ctx.invoke(self.callback, **ctx.params)
    File "/usr/local/lib/python3.9/dist-packages/click/core.py", line 555, in invoke
      return callback(*args, **kwargs)
    File "/usr/local/lib/python3.9/dist-packages/sfputil/main.py", line 557, in eeprom
      output += convert_sfp_info_to_output_string(xcvr_info)
    File "/usr/local/lib/python3.9/dist-packages/sfputil/main.py", line 279, in convert_sfp_info_to_output_string
      output += '{}{}: {}\n'.format(indent, QSFP_DATA_MAP[key], sfp_info_dict[key])
  TypeError: 'NoneType' object is not subscriptable
  root@sonic-10431:

**After fix:**
sfputil show eeprom -p Ethernet80
  Ethernet80: SFP EEPROM detected
          Application Advertisement: N/A
          Connector: No separable connector
          Encoding: Unspecified
          Extended Identifier: Power Class 1 Module (1.5W max. Power consumption), No CLEI code present in Page 02h, No CDR in TX, No CDR in RX
          Extended RateSelect Compliance: QSFP+ Rate Select Version 1
          Identifier: QSFP+ or later with SFF-8636 or SFF-8436
          Length Cable Assembly(m): 1.0
          Nominal Bit Rate(100Mbs): 103
          Specification compliance:
                  10/40G Ethernet Compliance Code: 40GBASE-CR4
                  Fibre Channel Link Length: Medium (M)
                  Fibre Channel Speed: Unknown
                  Fibre Channel Transmission Media: Twin Axial Pair (TW)
                  Fibre Channel Transmitter Technology: Unknown
                  Gigabit Ethernet Compliant Codes: Unknown
                  SAS/SATA Compliance Codes: Unknown
                  SONET Compliance Codes: Unknown
          Vendor Date Code(YYYY-MM-DD Lot): 2019-01-09
          Vendor Name: Amphenol
          Vendor OUI: 78-a7-14
          Vendor PN: 616750000
          Vendor Rev: C
          Vendor SN: CN01M31V9172909
  root@sonic-10431:~#
  
