### PR TITLE
Add recycle port to the physical ignore list

### DIFF
--- a/sonic_platform_base/sonic_sfp/sfputilbase.py
+++ b/sonic_platform_base/sonic_sfp/sfputilbase.py
@@ -15,7 +15,7 @@ try:
     from natsort import natsorted
     from portconfig import get_port_config
     from sonic_py_common import device_info
-    from sonic_py_common.interface import backplane_prefix, inband_prefix
+    from sonic_py_common.interface import backplane_prefix, inband_prefix, recirc_prefix
 
     from sonic_eeprom import eeprom_dts
     from .sff8472 import sff8472InterfaceId  # Dot module supports both Python 2 and Python 3 using explicit relative import methods
@@ -499,7 +499,7 @@ class SfpUtilBase(object):
                 portname = line.split()[0]
 
                 # Ignore if this is an internal backplane interface and Inband interface
-                if portname.startswith(backplane_prefix()) or portname.startswith(inband_prefix()):
+                if portname.startswith((backplane_prefix(), inband_prefix(), recirc_prefix())):
                     continue
 
                 bcm_port = str(port_pos_in_file)

--- a/sonic_platform_base/sonic_sfp/sfputilhelper.py
+++ b/sonic_platform_base/sonic_sfp/sfputilhelper.py
@@ -14,7 +14,7 @@ try:
     from natsort import natsorted
     from portconfig import get_port_config
     from sonic_py_common import device_info
-    from sonic_py_common.interface import backplane_prefix, inband_prefix
+    from sonic_py_common.interface import backplane_prefix, inband_prefix, recirc_prefix
 
 except ImportError as e:
     raise ImportError("%s - required module not found" % str(e))
@@ -128,7 +128,7 @@ class SfpUtilHelper(object):
                 portname = line.split()[0]
 
                 # Ignore if this is an internal backplane interface and Inband interface
-                if portname.startswith(backplane_prefix()) or portname.startswith(inband_prefix()):
+                if portname.startswith((backplane_prefix(), inband_prefix(), recirc_prefix())):
                     continue
 
                 bcm_port = str(port_pos_in_file)


### PR DESCRIPTION
#### Description

Prevent SFP logic from happening on non xcvr ports.

#### Motivation and Context

Recirculation ports are not physical ports and need to be ignored by xcvrd.
Not ignoring this port would lead to xcvrd calling get_sfp() on an unsupported interface and therefore crashing.

#### How Has This Been Tested?

Change applied manually to a switch with its dependency https://github.com/Azure/sonic-buildimage/pull/9471
Confirmed that xcvrd no longer tries to access the `Ethernet-Rec` ports
