### PR TITLE
[ssd] Allow individual vendor parsers to handle errors

### DIFF
--- a/sonic_platform_base/sonic_ssd/ssd_generic.py
+++ b/sonic_platform_base/sonic_ssd/ssd_generic.py
@@ -63,9 +63,6 @@ class SsdUtil(SsdBase):
     def _execute_shell(self, cmd):
         process = subprocess.Popen(cmd.split(), universal_newlines=True, stdout=subprocess.PIPE)
         output, error = process.communicate()
-        exit_code = process.returncode
-        if exit_code:
-            return None
         return output
 
     def _parse_re(self, pattern, buffer):


### PR DESCRIPTION
#### Description

Removed a `return None` in the command execution helper function `_execute_shell` in the SSD class so that command output is still parsed in the event of a non-zero exit code. 

#### Motivation and Context

If there is an issue found with a SSD SMART utilities may return a non-zero error code and we would still want to parse the output so we should not bail.

In addition, with the `return None` the parsing functions throw stack traces during execution. When removed, the parsing functions are able to elegantly handle missing information and the fields are left as `N/A` so there is no need for handling here. 

#### How Has This Been Tested?

Tested manually on a SN2010 with a malfunctioning SSD which was initially throwing stack traces and now handles the error elegantly reporting the health as `N/A` a much more informative error than a python stack trace. 