### PR TITLE
[202012][sonic_sfp]: prefer Config DB port index mapping over platform.json/port_config.ini

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -17,12 +17,12 @@ container:
 steps:
 - task: DownloadPipelineArtifact@2
   inputs:
-    source: specific
-    project: build
-    pipeline: 1
-    artifact: sonic-buildimage.vs
+    source: 'specific'
+    project: 'build'
+    pipeline: 142
+    artifact: 'sonic-buildimage.vs'
     runVersion: 'latestFromBranch'
-    runBranch: 'refs/heads/master'
+    runBranch: 'refs/heads/202012'
   displayName: "Download artifacts from latest sonic-buildimage build"
 
 - script: |

--- a/sonic_platform_base/sonic_sfp/sfputilhelper.py
+++ b/sonic_platform_base/sonic_sfp/sfputilhelper.py
@@ -56,6 +56,9 @@ class SfpUtilHelper(object):
         ports = ast.literal_eval(json.dumps(ports_data))
         for port in ports.keys():
             if "index" not in ports[port]:
+                print("Failed to get port config: invalid port entry {}: index field doesn't exist".format(port),
+                    file=sys.stderr
+                )
                 return None
 
         return ports

--- a/sonic_platform_base/sonic_sfp/sfputilhelper.py
+++ b/sonic_platform_base/sonic_sfp/sfputilhelper.py
@@ -48,10 +48,13 @@ class SfpUtilHelper(object):
         pass
 
     def get_port_mapping(self, asic_inst):
-        if multi_asic.is_multi_asic():
-            ports_data = multi_asic.get_port_table_for_asic("{}{}".format(multi_asic.ASIC_NAME_PREFIX, asic_inst))
-        else:
-            ports_data = multi_asic.get_port_table_for_asic(multi_asic.DEFAULT_NAMESPACE)
+        try:
+            if multi_asic.is_multi_asic():
+                ports_data = multi_asic.get_port_table_for_asic("{}{}".format(multi_asic.ASIC_NAME_PREFIX, asic_inst))
+            else:
+                ports_data = multi_asic.get_port_table_for_asic(multi_asic.DEFAULT_NAMESPACE)
+        except Exception as e:
+            return None
 
         ports = ast.literal_eval(json.dumps(ports_data))
         for port in ports.keys():


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

#### Description
<!--
     Describe your changes in detail
-->
**Approach:**
1. Always use Config DB to get port mapping when it's available
2. When port mapping is missing in Config DB, use either `platform.json` or `port_config.ini`

On `multiasic` platforms the relevant Config DB instance will be used

#### Motivation and Context
<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->
* Always read port mapping from Config DB when it's available
* Fallback to `platform.json` or `port_config.ini` if needed

#### How Has This Been Tested?
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->
* manually tested

#### Additional Information (Optional)
* N/A