### PR TITLE
[ycable][credo] Fix the is_link_active API for Credo Ycable

### DIFF
--- a/sonic_y_cable/credo/y_cable_credo.py
+++ b/sonic_y_cable/credo/y_cable_credo.py
@@ -740,15 +740,24 @@ class YCable(YCableBase):
 
         regval_read = struct.unpack(">B", result)
 
-        if (regval_read[0] & 0x01):
-            self.log_info("NIC link is up")
-            return True
-        elif ((regval_read[0] >> 2) & 0x01):
-            self.log_info("TOR A link is up")
-            return True
-        elif ((regval_read[0] >> 1) & 0x01):
-            self.log_info("TOR B link is up")
-            return True
+        if target == YCableBase.TARGET_NIC:
+            if (regval_read[0] & 0x01):
+                self.log_info("NIC link is up")
+                return True
+            else:
+                return False
+        elif target == YCableBase.TARGET_TOR_A:
+            if ((regval_read[0] >> 2) & 0x01):
+                self.log_info("TOR A link is up")
+                return True
+            else:
+                return False
+        elif target == YCableBase.TARGET_TOR_B:
+            if ((regval_read[0] >> 1) & 0x01):
+                self.log_info("TOR B link is up")
+                return True
+            else:
+                return False
         else:
             return YCableBase.TARGET_UNKNOWN
 


### PR DESCRIPTION
Signed-off-by: vaibhav-dahiya <vdahiya@microsoft.com>

<!-- Provide a general summary of your changes in the Title above -->

#### Description
Currently is_link_active API was broken because it was not using the target param in the routine to give back the correct link_status of ecah side. With this change it gives the correct result. 
<!--
     Describe your changes in detail
-->

#### Motivation and Context
Required for MUX_CABLE_INFO table in streaming telemetry if the cable is disconnected or the link is down. 

```
redis-cli -n 6 hgetall "MUX_CABLE_INFO|Ethernet16"
"
 9) "link_status_self"
10) "down"
11) "link_status_peer"
12) "up"
13) "link_status_nic"
14) "up"
```
<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->

#### How Has This Been Tested?
Tested on actual Arista7050cx3 testbed. 
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->

#### Additional Information (Optional)

