### PR TITLE
[sonic_sfp] Interpret sff 'int' element =0 as valid value

### DIFF
--- a/sonic_platform_base/sonic_sfp/sffbase.py
+++ b/sonic_platform_base/sonic_sfp/sffbase.py
@@ -132,9 +132,7 @@ class sffbase(object):
                               offset + size)
 
         elif type == 'int':
-            data = int(eeprom_data[offset], 16)
-            if data != 0:
-                value = data
+            value = int(eeprom_data[offset], 16)
 
         elif type == 'date':
             value = self.convert_date_to_string(eeprom_data, offset,


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

#### Description
In get_transceiver_info_dict() an exception is generated on access to sfp_interface_bulk_data element that was not added in case SFP EEPROM 'int' value was zero. Actually, zero should be valid value as well.

This is a cherry-pick of  [PR51](https://github.com/Azure/sonic-platform-common/pull/51)

#### How Has This Been Tested?
Verified that the Xcvrd doesn't crash while parsing 'Nominal bit rate' field when the byte is '0'

#### Additional Information (Optional)

