### PR TITLE
[sfputil]Refactoring read_porttab_mappings

### DIFF
--- a/sonic_platform_base/sonic_sfp/sfputilhelper.py
+++ b/sonic_platform_base/sonic_sfp/sfputilhelper.py
@@ -49,139 +49,46 @@ class SfpUtilHelper(object):
         logical = []
         logical_to_physical = {}
         physical_to_logical = {}
-        last_fp_port_index = 0
-        last_portname = ""
-        first = 1
-        port_pos_in_file = 0
-        parse_fmt_port_config_ini = False
-        parse_fmt_platform_json = False
-
-        parse_fmt_port_config_ini = (os.path.basename(porttabfile) == PORT_CONFIG_INI)
-        parse_fmt_platform_json = (os.path.basename(porttabfile) == PLATFORM_JSON)
+        fp_port_index = 1
 
         (platform, hwsku) = device_info.get_platform_and_hwsku()
-        if(parse_fmt_platform_json):
-            ports, _, _ = get_port_config(hwsku, platform)
+        ports, _, _ = get_port_config(hwsku, platform)
+
+        if not ports:
+            ports, _, _ = get_port_config(hwsku, platform, porttabfile)
             if not ports:
                 print('Failed to get port config', file=sys.stderr)
                 sys.exit(1)
+
+        logical_list = []
+        for intf in ports.keys():
+             logical_list.append(intf)
+
+        logical = natsorted(logical_list, key=lambda y: y.lower())
+        # Ignore if this is an internal backplane interface and Inband interface
+        logical = [name for name in logical 
+                      if not name.startswith((backplane_prefix(), inband_prefix(), recirc_prefix()))]
+        logical_to_physical, physical_to_logical = OrderedDict(),  OrderedDict()
+
+        for intf_name in logical:
+            if 'index' in ports[intf_name].keys():
+                fp_port_index = int(ports[intf_name]['index'])
+                logical_to_physical[intf_name] = [fp_port_index]
+
+            if physical_to_logical.get(fp_port_index) is None:
+                physical_to_logical[fp_port_index] = [intf_name]
             else:
-                logical_list = []
-                for intf in ports.keys():
-                    logical_list.append(intf)
-
-                logical = natsorted(logical_list, key=lambda y: y.lower())
-                logical_to_physical, physical_to_logical = OrderedDict(),  OrderedDict()
-
-                for intf_name in logical:
-                    bcm_port = str(port_pos_in_file)
-
-                    if 'index' in ports[intf_name].keys():
-                        fp_port_index = int(ports[intf_name]['index'])
-                        logical_to_physical[intf_name] = [fp_port_index]
-
-                    if physical_to_logical.get(fp_port_index) is None:
-                        physical_to_logical[fp_port_index] = [intf_name]
-                    else:
-                        physical_to_logical[fp_port_index].append(intf_name)
-
-                    # Mapping of logical port names available on a system to ASIC instance
-                    self.logical_to_asic[intf_name] = asic_inst
-                    port_pos_in_file +=1
-
-                self.logical = logical
-                self.logical_to_physical = logical_to_physical
-                self.physical_to_logical = physical_to_logical
-
-                """
-                print("logical: {}".format(self.logical))
-                print("logical to physical: {}".format(self.logical_to_physical))
-                print("physical to logical: {}".format( self.physical_to_logical))
-                """
-                return None
-
-
-        try:
-            f = open(porttabfile)
-        except Exception:
-            raise
-
-        # Read the porttab file and generate dicts
-        # with mapping for future reference.
-        #
-        # TODO: Refactor this to use the portconfig.py module that now
-        # exists as part of the sonic-config-engine package.
-        title = []
-        for line in f:
-            line.strip()
-            if re.search("^#", line) is not None:
-                # The current format is: # name lanes alias index speed
-                # Where the ordering of the columns can vary
-                title = line.split()[1:]
-                continue
-
-            # Parsing logic for 'port_config.ini' file
-            if (parse_fmt_port_config_ini):
-                # bcm_port is not explicitly listed in port_config.ini format
-                # Currently we assume ports are listed in numerical order according to bcm_port
-                # so we use the port's position in the file (zero-based) as bcm_port
-                portname = line.split()[0]
-
-                # Ignore if this is an internal backplane interface and Inband interface
-                if portname.startswith((backplane_prefix(), inband_prefix(), recirc_prefix())):
-                    continue
-
-                bcm_port = str(port_pos_in_file)
-
-                if "index" in title:
-                    fp_port_index = int(line.split()[title.index("index")])
-                # Leave the old code for backward compatibility
-                elif "asic_port_name" not in title and len(line.split()) >= 4:
-                    fp_port_index = int(line.split()[3])
-                else:
-                    fp_port_index = portname.split("Ethernet").pop()
-                    fp_port_index = int(fp_port_index.split("s").pop(0))/4
-            else:  # Parsing logic for older 'portmap.ini' file
-                (portname, bcm_port) = line.split("=")[1].split(",")[:2]
-
-                fp_port_index = portname.split("Ethernet").pop()
-                fp_port_index = int(fp_port_index.split("s").pop(0))/4
-
-            if ((len(self.sfp_ports) > 0) and (fp_port_index not in self.sfp_ports)):
-                continue
-
-            if first == 1:
-                # Initialize last_[physical|logical]_port
-                # to the first valid port
-                last_fp_port_index = fp_port_index
-                last_portname = portname
-                first = 0
-
-            logical.append(portname)
+                physical_to_logical[fp_port_index].append(intf_name)
 
             # Mapping of logical port names available on a system to ASIC instance
-            self.logical_to_asic[portname] = asic_inst
+            self.logical_to_asic[intf_name] = asic_inst
 
-            logical_to_physical[portname] = [fp_port_index]
-            if physical_to_logical.get(fp_port_index) is None:
-                physical_to_logical[fp_port_index] = [portname]
-            else:
-                physical_to_logical[fp_port_index].append(portname)
+        self.logical = logical
+        self.logical_to_physical = logical_to_physical
+        self.physical_to_logical = physical_to_logical
 
-            last_fp_port_index = fp_port_index
-            last_portname = portname
+        return None
 
-            port_pos_in_file += 1
-
-        self.logical.extend(logical)
-        self.logical_to_physical.update(logical_to_physical)
-        self.physical_to_logical.update(physical_to_logical)
-
-        """
-        print("logical: " + self.logical)
-        print("logical to physical: " + self.logical_to_physical)
-        print("physical to logical: " + self.physical_to_logical)
-        """
 
     def read_all_porttab_mappings(self, platform_dir, num_asic_inst):
         # In multi asic scenario, get all the port_config files for different asics

--- a/sonic_platform_base/sonic_sfp/sfputilhelper.py
+++ b/sonic_platform_base/sonic_sfp/sfputilhelper.py
@@ -64,10 +64,10 @@ class SfpUtilHelper(object):
         for intf in ports.keys():
              logical_list.append(intf)
 
-        logical = natsorted(logical_list, key=lambda y: y.lower())
         # Ignore if this is an internal backplane interface and Inband interface
         logical = [name for name in logical 
                       if not name.startswith((backplane_prefix(), inband_prefix(), recirc_prefix()))]
+        logical = natsorted(logical_list, key=lambda y: y.lower())
         logical_to_physical, physical_to_logical = OrderedDict(),  OrderedDict()
 
         for intf_name in logical:


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

#### Description
<!--
     Describe your changes in detail
-->

#### Motivation and Context
<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->
Refactored sfputilhelper API read_porttab_mappings. This API has duplicate logic as done inside get_port_config.
The get_port_config has logic to first look into config_db, fallback to hwsku/platform.json, fallback to port_config.ini. Additionally added another fallback to look into the porttabfile to allow custom porttabfile to be used.


#### How Has This Been Tested?
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->

Ran some basic platform tests. Existing UT should also cover these changes


#### Additional Information (Optional)

This is to address review comment in https://github.com/Azure/sonic-platform-common/pull/258#discussion_r786128567