### PR TITLE
[SSD Generic] Add support for parsing nvme ssd model, health and temperature

### DIFF
--- a/sonic_platform_base/sonic_ssd/ssd_generic.py
+++ b/sonic_platform_base/sonic_ssd/ssd_generic.py
@@ -74,11 +74,17 @@ class SsdUtil(SsdBase):
 
     # Health and temperature values may be overwritten with vendor specific data
     def parse_generic_ssd_info(self):
-        self.model = self._parse_re('Device Model:\s*(.+?)\n', self.ssd_info)
+        if "nvme" in self.dev:
+            self.model = self._parse_re('Model Number:\s*(.+?)\n', self.ssd_info)
+            health_raw = self._parse_re('Percentage Used\s*(.+?)\n', self.ssd_info).split()[-1]
+            self.health = 100 - float(health_raw.strip('%'))
+            self.temperature = float(self._parse_re('Temperature\s*(.+?)\n', self.ssd_info).split()[-2])
+        else:
+            self.model = self._parse_re('Device Model:\s*(.+?)\n', self.ssd_info)
+            self.health = self._parse_re('Remaining_Lifetime_Perc\s*(.+?)\n', self.ssd_info).split()[-1]
+            self.temperature = self._parse_re('Temperature_Celsius\s*(.+?)\n', self.ssd_info).split()[-6]
         self.serial = self._parse_re('Serial Number:\s*(.+?)\n', self.ssd_info)
         self.firmware = self._parse_re('Firmware Version:\s*(.+?)\n', self.ssd_info)
-        self.health = self._parse_re('Remaining_Lifetime_Perc\s*(.+?)\n', self.ssd_info).split()[-1]
-        self.temperature = self._parse_re('Temperature_Celsius\s*(.+?)\n', self.ssd_info).split()[-6]
 
     def parse_innodisk_info(self):
         self.health = self._parse_re('Health:\s*(.+?)%', self.vendor_ssd_info)

--- a/tests/ssd_generic_test.py
+++ b/tests/ssd_generic_test.py
@@ -1,0 +1,84 @@
+
+import sys
+if sys.version_info.major == 3:
+    from unittest import mock
+else:
+    import mock
+
+from sonic_platform_base.sonic_ssd.ssd_generic import SsdUtil
+
+output_nvme_ssd = """smartctl 7.2 2020-12-30 r5155 [x86_64-linux-5.10.0-8-2-amd64] (local build)
+Copyright (C) 2002-20, Bruce Allen, Christian Franke, www.smartmontools.org
+
+=== START OF INFORMATION SECTION ===
+Model Number:                       SFPC020GM1EC2TO-I-5E-11P-STD
+Serial Number:                      A0221030722410000027
+Firmware Version:                   COT6OQ
+PCI Vendor/Subsystem ID:            0x1dd4
+IEEE OUI Identifier:                0x8c6078
+Controller ID:                      1
+NVMe Version:                       1.3
+Number of Namespaces:               1
+Namespace 1 Size/Capacity:          20,014,718,976 [20.0 GB]
+Namespace 1 Formatted LBA Size:     512
+Namespace 1 IEEE EUI-64:            486834 133070001b
+Local Time is:                      Tue Mar  1 06:35:23 2022 UTC
+Firmware Updates (0x12):            1 Slot, no Reset required
+Optional Admin Commands (0x0016):   Format Frmw_DL Self_Test
+Optional NVM Commands (0x001f):     Comp Wr_Unc DS_Mngmt Wr_Zero Sav/Sel_Feat
+Log Page Attributes (0x0e):         Cmd_Eff_Lg Ext_Get_Lg Telmtry_Lg
+Maximum Data Transfer Size:         64 Pages
+Warning  Comp. Temp. Threshold:     105 Celsius
+Critical Comp. Temp. Threshold:     120 Celsius
+
+Supported Power States
+St Op     Max   Active     Idle   RL RT WL WT  Ent_Lat  Ex_Lat
+ 0 +     3.50W       -        -    0  0  0  0        0       0
+ 1 +     2.50W       -        -    1  1  1  1        0       0
+ 2 +     1.50W       -        -    2  2  2  2        0       0
+ 3 -   0.0200W       -        -    3  3  3  3     2200    3000
+ 4 -   0.0100W       -        -    4  4  4  4    15000   12000
+
+Supported LBA Sizes (NSID 0x1)
+Id Fmt  Data  Metadt  Rel_Perf
+ 0 +     512       0         0
+
+=== START OF SMART DATA SECTION ===
+SMART overall-health self-assessment test result: PASSED
+
+SMART/Health Information (NVMe Log 0x02)
+Critical Warning:                   0x00
+Temperature:                        37 Celsius
+Available Spare:                    100%
+Available Spare Threshold:          10%
+Percentage Used:                    0%
+Data Units Read:                    1,546,369 [791 GB]
+Data Units Written:                 7,118,163 [3.64 TB]
+Host Read Commands:                 27,027,268
+Host Write Commands:                87,944,082
+Controller Busy Time:               5,660
+Power Cycles:                       455
+Power On Hours:                     3,638
+Unsafe Shutdowns:                   435
+Media and Data Integrity Errors:    0
+Error Information Log Entries:      5,275
+Warning  Comp. Temperature Time:    0
+Critical Comp. Temperature Time:    0
+Temperature Sensor 1:               41 Celsius
+Temperature Sensor 2:               38 Celsius
+
+Error Information (NVMe Log 0x01, 16 of 64 entries)
+Num   ErrCount  SQId   CmdId  Status  PELoc          LBA  NSID    VS
+  0       5275     0  0x0001  0x0004      -            0     1     -"""
+
+class TestSsdGeneric:
+    @mock.patch('sonic_platform_base.sonic_ssd.ssd_generic.SsdUtil._execute_shell', mock.MagicMock(return_value=output_nvme_ssd))
+    def test_nvme_ssd(self):
+        nvme_ssd = SsdUtil('/dev/nvme0n1')
+        assert(nvme_ssd.get_health() == 100.0)
+        assert(nvme_ssd.get_model() == 'SFPC020GM1EC2TO-I-5E-11P-STD')
+        assert(nvme_ssd.get_firmware() == "COT6OQ")
+        assert(nvme_ssd.get_temperature() == 37)
+        assert(nvme_ssd.get_serial() == "A0221030722410000027")
+
+


### PR DESCRIPTION
Signed-off-by: Kebo Liu <kebol@nvidia.com>

<!-- Provide a general summary of your changes in the Title above -->

#### Description
enhance ssd_generic to support parsing NVME SSD info from smartctl output
Add test case for new added nvme parsing logic

#### Motivation and Context
<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->
in the output of smartctl, the related keys for NVME SSD are different: 

- model info key is "Model Number"
- "Percentage Used" indicates the wear-out level
- "Temperature"  provides the thermal info

The new change will look for the above keys when the device is nvme SSD

below is an example of smartctl output on an NVME SSD

```
root@sonic:/home/admin# smartctl -a /dev/nvme0n1
smartctl 7.2 2020-12-30 r5155 [x86_64-linux-5.10.0-8-2-amd64] (local build)
Copyright (C) 2002-20, Bruce Allen, Christian Franke, [www.smartmontools.org](https://nam11.safelinks.protection.outlook.com/?url=http%3A%2F%2Fwww.smartmontools.org%2F&data=04%7C01%7Ckebol%40nvidia.com%7C7bd4d46f236441d936d608d9f695d1ad%7C43083d15727340c1b7db39efd9ccc17a%7C0%7C0%7C637811945587622712%7CUnknown%7CTWFpbGZsb3d8eyJWIjoiMC4wLjAwMDAiLCJQIjoiV2luMzIiLCJBTiI6Ik1haWwiLCJXVCI6Mn0%3D%7C3000&sdata=I6Q%2Fsbo1sucai1mMCygQrN5mEGS1ZrHTQYIbfIRqTw0%3D&reserved=0)

=== START OF INFORMATION SECTION ===
Model Number:                       SFPC020GM1EC2TO-I-5E-11P-STD
Serial Number:                      A0221030722410000027
Firmware Version:                   COT6OQ
PCI Vendor/Subsystem ID:            0x1dd4
IEEE OUI Identifier:                0x8c6078

……

Supported LBA Sizes (NSID 0x1)
Id Fmt  Data  Metadt  Rel_Perf
0 +     512       0         0

=== START OF SMART DATA SECTION ===
SMART overall-health self-assessment test result: PASSED

SMART/Health Information (NVMe Log 0x02)
Critical Warning:                   0x00
Temperature:                        43 Celsius
Available Spare:                    100%
Available Spare Threshold:          10%
Percentage Used:                    0%
Data Units Read:                    1,302,451 [666 GB]
Data Units Written:                 6,251,447 [3.20 TB]
Host Read Commands:                 23,534,308
Host Write Commands:                77,179,910
Controller Busy Time:               4,861
Power Cycles:                       454
Power On Hours:                     3,209
Unsafe Shutdowns:                   434
Media and Data Integrity Errors:    0
Error Information Log Entries:      4,636
Warning  Comp. Temperature Time:    0
Critical Comp. Temperature Time:    0
Temperature Sensor 1:               47 Celsius
Temperature Sensor 2:               44 Celsius

Error Information (NVMe Log 0x01, 16 of 64 entries)
Num   ErrCount  SQId   CmdId  Status  PELoc          LBA  NSID    VS
  0       4636     0  0x0008  0x0004      -            0     1     -
  1       4635     0  0x001a  0x0004      -            0     1     -
  2       4634     0  0x0009  0x0004      -            0     1     -
```

#### How Has This Been Tested?

test ssdutil works as expected.
test show platform ssdhealth works as expected

#### Additional Information (Optional)

