### PR TITLE
[Credo][Ycable] Fix Credo firmware download API download_firmware flag

### DIFF
--- a/sonic_y_cable/credo/y_cable_credo.py
+++ b/sonic_y_cable/credo/y_cable_credo.py
@@ -1534,6 +1534,8 @@ class YCable(YCableBase):
             self.log_error("platform_chassis is not loaded, failed to download firmware")
             return YCable.EEPROM_ERROR
 
+        self.download_firmware_status = self.FIRMWARE_DOWNLOAD_STATUS_NOT_INITIATED_OR_FINISHED
+
         return YCableBase.FIRMWARE_DOWNLOAD_SUCCESS
 
     def activate_firmware(self, fwfile=None, hitless=False):


### PR DESCRIPTION
Signed-off-by: vaibhav-dahiya <vdahiya@microsoft.com>

Due to PR https://github.com/Azure/sonic-platform-common/pull/222
the download_firmware_status variable of download_firmware API was not cleaned up, due to which higher layer
could sometimes see wrong values of firmware version.
This PR addresses this issue. 

After calling a firmware download and not changing this variable
```

admin@sonic:~$ show mux firmware version Ethernet0
{
    "version_nic_active": "N/A",
    "version_nic_inactive": "N/A",
    "version_nic_next": "N/A",
    "version_peer_active": "N/A",
    "version_peer_inactive": "N/A",
    "version_peer_next": "N/A",
    "version_self_active": "N/A",
    "version_self_inactive": "N/A",
    "version_self_next": "N/A"
}
```
after the change
```
admin@sonic:~$ show mux firmware version Ethernet0
<versionX>
{
    "version_nic_active": "1.0MS",
    "version_nic_inactive": "1.1MS",
    "version_nic_next": "1.0MS",
    "version_peer_active": "1.0MS",
    "version_peer_inactive": "1.1MS",
    "version_peer_next": "1.0MS",
    "version_self_active": "1.0MS",
    "version_self_inactive": "1.1MS",
    "version_self_next": "1.0MS"
}
```

<!-- Provide a general summary of your changes in the Title above -->

#### Description
<!--
     Describe your changes in detail
-->

#### Motivation and Context
<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->

#### How Has This Been Tested?
Tested on an Arista Device.
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->

#### Additional Information (Optional)

