### PR TITLE
[syseeprom] Enable display of vendor extension TLV content

### DIFF
--- a/sonic_platform_base/sonic_eeprom/eeprom_tlvinfo.py
+++ b/sonic_platform_base/sonic_eeprom/eeprom_tlvinfo.py
@@ -68,7 +68,7 @@ class TlvInfoDecoder(eeprom_base.EepromDecoder):
     _TLV_CODE_QUANTA_MODEL_NAME = _TLV_CODE_UNDEFINED
 
     # TLV Value Display Switch
-    _TLV_DISPLAY_VENDOR_EXT     = False
+    _TLV_DISPLAY_VENDOR_EXT     = True
 
 
     def __init__(self, path, start, status, ro, max_len=_TLV_INFO_MAX_LEN):


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->

#### Description
<!--
     Describe your changes in detail
-->
The code that decodes the content of the ONIE syseeprom includes a flag to
enable/disable displaying the content of the vendor extension TLV. This flag is
currently set to 'disable'. Hence the 'show platform syseeprom' command shows
the presence and size of the vendor extension TLV but does not show its
content. This commit sets the flag to 'enable' so that the vendor extension TLV
content is displayed.

#### Motivation and Context
<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->

The 'show platform syseeprom' command shows that the Vendor Extension TLV is present but does not show its content.
Here's what that looks like on an example platform.

```
admin@sonic:~$ show platform syseeprom

TlvInfo Header:
   Id String:    TlvInfo
   Version:      1
   Total Length: 177
TLV Name             Code Len Value
-------------------- ---- --- -----
Product Name         0x21  11 7215 IXS-T1
Part Number          0x22  14 3HE16794AARB01
Serial Number        0x23  11 NK214810028
Base MAC Address     0x24   6 AC:8F:F8:50:AC:3D
Manufacture Date     0x25  19 11/30/2021 16:53:36
Platform Name        0x28  26 armhf-nokia_ixs7215_52x-r0
ONIE Version         0x29  45 2019.11-onie_version-nokia_ixs7215_52x-v1.5.1
MAC Addresses        0x2A   2 64
Service Tag          0x2F  10 CSM9W00FRA
Vendor Extension     0xFD   7 
CRC-32               0xFE   4 0x21DE1669
```

#### How Has This Been Tested?
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->

With this fix in place the command output now looks as follows.
```
admin@sonic:~$ show platform syseeprom
TlvInfo Header:
   Id String:    TlvInfo
   Version:      1
   Total Length: 177
TLV Name          Code      Len  Value
----------------  ------  -----  ---------------------------------------------
Product Name      0x21       11  7215 IXS-T1
Part Number       0x22       14  3HE16794AA0101
Serial Number     0x23       11  NK204510002
Base MAC Address  0x24        6  50:E0:EF:6E:EC:11
Manufacture Date  0x25       19  11/06/2020 14:45:02
Platform Name     0x28       26  armhf-nokia_ixs7215_52x-r0
ONIE Version      0x29       45  2019.11-onie_version-nokia_ixs7215_52x-v1.5.1
MAC Addresses     0x2A        2  64
Service Tag       0x2F       10  CSM9W00FRA
Vendor Extension  0xFD        7  0x00 0x00 0x19 0x7F 0x01 0x01 0xB5
CRC-32            0xFE        4  0x34885B1D
```

#### Additional Information (Optional)

