### PR TITLE
[Credo][Ycable] improve logging for Server Powered off/Faulty cables

### DIFF
--- a/sonic_y_cable/credo/y_cable_credo.py
+++ b/sonic_y_cable/credo/y_cable_credo.py
@@ -617,7 +617,7 @@ class YCable(YCableBase):
             self.log_info("Reading from NIC side")
             return YCableBase.TARGET_NIC
         else:
-            self.log_error("Error: unknown status for checking which side regval = {} ".format(result))
+            self.log_error("Error: Credo Y Cable unable to get the read side, Cable not plugged/Faulty Cable register value = {} ".format(result))
 
         return YCableBase.TARGET_UNKNOWN
 
@@ -675,7 +675,7 @@ class YCable(YCableBase):
             self.log_info("mux pointing to TOR B")
             return YCableBase.TARGET_TOR_B
 
-        self.log_error("Error: unknown status for mux direction regval = {} ".format(result))
+        self.log_error("Error: Credo Y Cable unable to check the status mux direction, cable powered off/Faulty Cable register value = {}".format(result))
         return YCableBase.TARGET_UNKNOWN
 
     def get_active_linked_tor_side(self):
@@ -736,7 +736,7 @@ class YCable(YCableBase):
             self.log_info("Nothing linked for routing")
             return YCableBase.TARGET_NIC
 
-        self.log_error("Error: unknown status for active TOR regval = {} ".format(result))
+        self.log_error("Error: Credo Y Cable unable to get active linked ToR side Cable powered off/Faulty Cable register value = {} ".format(result))
         return YCableBase.TARGET_UNKNOWN
 
     def is_link_active(self, target):


### PR DESCRIPTION
Signed-off-by: vaibhav-dahiya <vdahiya@microsoft.com>
Cable could be powered off during which the i2c to the NIC MCU would not be able to respond with which side is active. 
For such cases the log needs to be improved.
In case the cable is powered correctly but still the cable is not able to get the actve side, that would mean a faulty cable.
Added/improved the appropriate logs

<!-- Provide a general summary of your changes in the Title above -->

#### Description
<!--
     Describe your changes in detail
-->

#### Motivation and Context
<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->

#### How Has This Been Tested?
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->

#### Additional Information (Optional)

