### PR TITLE
Add new reboot-cause to cover more scenarios

### DIFF
--- a/sonic_platform_base/chassis_base.py
+++ b/sonic_platform_base/chassis_base.py
@@ -24,6 +24,10 @@ class ChassisBase(device_base.DeviceBase):
     REBOOT_CAUSE_INSUFFICIENT_FAN_SPEED = "Insufficient Fan Speed"
     REBOOT_CAUSE_WATCHDOG = "Watchdog"
     REBOOT_CAUSE_HARDWARE_OTHER = "Hardware - Other"
+    REBOOT_CAUSE_HARDWARE_BIOS = "BIOS"
+    REBOOT_CAUSE_HARDWARE_CPU = "CPU"
+    REBOOT_CAUSE_HARDWARE_BUTTON = "Push button"
+    REBOOT_CAUSE_HARDWARE_RESET_FROM_ASIC = "Reset from ASIC"
     REBOOT_CAUSE_NON_HARDWARE = "Non-Hardware"
 
     def __init__(self):

--- a/tests/chassis_base_test.py
+++ b/tests/chassis_base_test.py
@@ -1,0 +1,18 @@
+from sonic_platform_base.chassis_base import ChassisBase
+
+class TestChassisBase:
+
+    def test_reboot_cause(self):
+        chassis = ChassisBase()
+        assert(chassis.REBOOT_CAUSE_POWER_LOSS == "Power Loss")
+        assert(chassis.REBOOT_CAUSE_THERMAL_OVERLOAD_CPU == "Thermal Overload: CPU")
+        assert(chassis.REBOOT_CAUSE_THERMAL_OVERLOAD_ASIC == "Thermal Overload: ASIC")
+        assert(chassis.REBOOT_CAUSE_THERMAL_OVERLOAD_OTHER == "Thermal Overload: Other")
+        assert(chassis.REBOOT_CAUSE_INSUFFICIENT_FAN_SPEED == "Insufficient Fan Speed")
+        assert(chassis.REBOOT_CAUSE_WATCHDOG == "Watchdog")
+        assert(chassis.REBOOT_CAUSE_HARDWARE_OTHER == "Hardware - Other")
+        assert(chassis.REBOOT_CAUSE_HARDWARE_BIOS == "BIOS")
+        assert(chassis.REBOOT_CAUSE_HARDWARE_CPU == "CPU")
+        assert(chassis.REBOOT_CAUSE_HARDWARE_BUTTON == "Push button")
+        assert(chassis.REBOOT_CAUSE_HARDWARE_RESET_FROM_ASIC == "Reset from ASIC")
+        assert(chassis.REBOOT_CAUSE_NON_HARDWARE == "Non-Hardware")


### PR DESCRIPTION
Signed-off-by: Kebo Liu <kebol@nvidia.com>

<!-- Provide a general summary of your changes in the Title above -->

#### Description
Add some new reboot causes to cover followinging scenarios:

1.	**BIOS** - In case the BIOS upgrade process ended with failure and cause the switch to reset. 
2.	**CPU**  - Reset is initiated by SW on the CPU. it could be that SW encountered some catastrophic situation like a memory leak, eventually, the kernel reset the whole switch.
3.	**Push button**  -  Reset by pushing the reset button
4.	**Reset from ASIC** -  Reset which is caused by ASIC. 


#### Motivation and Context
Add more reboot causes to cover more scenarios.

#### How Has This Been Tested?
UT is added with the code change.
run community reboot test to see the reboot cause checker can pass.

#### Additional Information (Optional)

