### PR TITLE
[multiasic][sfputil]Fix the sftpuitlhelper on mutilasic platform issue

### DIFF
--- a/sonic_platform_base/sonic_sfp/bcmshell.py
+++ b/sonic_platform_base/sonic_sfp/bcmshell.py
@@ -227,7 +227,7 @@ class bcmshell (object):
         #
         t = self.re_oneline.sub('', t)
         t = t.split('\n')
-        if t[-1] is '':
+        if t[-1] == '':
             t.pop()
 
         # get the results into a dict (module) of lists (array) of values/fields
@@ -253,10 +253,10 @@ class bcmshell (object):
         # now optimize the return
         #
         for I in iter(d):
-            if len(d[I]) is 1:
+            if len(d[I]) == 1:
                 d[I] = d[I][0]
 
-        if len(d) is 1:
+        if len(d) == 1:
             return d.values()[0]
         else:
             return d
@@ -319,7 +319,7 @@ class bcmshell (object):
         t = self.re_table_header.sub('', t)
         t = self.re_table_trailer.sub('', t)
         t = t.split('\n')
-        if t[-1] is '':
+        if t[-1] == '':
             t.pop()
 
         # parse the contents

--- a/tests/0/port_config.ini
+++ b/tests/0/port_config.ini
@@ -5,10 +5,3 @@ Ethernet8       37,38,39,40       fortyGigE0/8      3
 Ethernet12      33,34,35,36       fortyGigE0/12     4
 Ethernet16      41,42,43,44       fortyGigE0/16     5
 Ethernet20      45,46,47,48       fortyGigE0/20     6
-Ethernet24      5,6,7,8           fortyGigE0/24     7
-Ethernet28      1,2,3,4           fortyGigE0/28     8
-Ethernet32      9,10,11,12        fortyGigE0/32     9
-Ethernet36      13,14,15,16       fortyGigE0/36     10
-Ethernet40      21,22,23,24       fortyGigE0/40     11
-Ethernet44      17,18,19,20       fortyGigE0/44     12
-Ethernet48      49,50,51,52       fortyGigE0/48     13

--- a/tests/1/port_config.ini
+++ b/tests/1/port_config.ini
@@ -1,10 +1,4 @@
-# name          lanes             alias             index
-Ethernet0       29,30,31,32       fortyGigE0/0      1
-Ethernet4       25,26,27,28       fortyGigE0/4      2
-Ethernet8       37,38,39,40       fortyGigE0/8      3
-Ethernet12      33,34,35,36       fortyGigE0/12     4
-Ethernet16      41,42,43,44       fortyGigE0/16     5
-Ethernet20      45,46,47,48       fortyGigE0/20     6
+# name          lanes             alias              index
 Ethernet24      5,6,7,8           fortyGigE0/24     7
 Ethernet28      1,2,3,4           fortyGigE0/28     8
 Ethernet32      9,10,11,12        fortyGigE0/32     9

--- a/tests/platform_json/hwsku.json
+++ b/tests/platform_json/hwsku.json
@@ -1,0 +1,46 @@
+{
+    "interfaces": {
+        "Ethernet0": {
+            "default_brkout_mode": "1x200G[100G,50G,40G,25G,10G,1G]"
+        },
+        "Ethernet4": {
+            "default_brkout_mode": "1x200G[100G,50G,40G,25G,10G,1G]"
+        },
+        "Ethernet8": {
+            "default_brkout_mode": "1x200G[100G,50G,40G,25G,10G,1G]"
+        },
+        "Ethernet12": {
+            "default_brkout_mode": "1x200G[100G,50G,40G,25G,10G,1G]"
+        },
+        "Ethernet16": {
+            "default_brkout_mode": "1x200G[100G,50G,40G,25G,10G,1G]"
+        },
+        "Ethernet20": {
+            "default_brkout_mode": "1x200G[100G,50G,40G,25G,10G,1G]"
+        },
+        "Ethernet24": {
+            "default_brkout_mode": "1x200G[100G,50G,40G,25G,10G,1G]"
+        },
+        "Ethernet28": {
+            "default_brkout_mode": "1x200G[100G,50G,40G,25G,10G,1G]"
+        },
+        "Ethernet32": {
+            "default_brkout_mode": "1x200G[100G,50G,40G,25G,10G,1G]"
+        },
+        "Ethernet36": {
+            "default_brkout_mode": "1x200G[100G,50G,40G,25G,10G,1G]"
+        },
+        "Ethernet40": {
+            "default_brkout_mode": "1x200G[100G,50G,40G,25G,10G,1G]"
+        },
+        "Ethernet44": {
+            "default_brkout_mode": "1x200G[100G,50G,40G,25G,10G,1G]"
+        },
+        "Ethernet48": {
+            "default_brkout_mode": "1x200G[100G,50G,40G,25G,10G,1G]"
+        },
+        "Ethernet52": {
+            "default_brkout_mode": "1x200G[100G,50G,40G,25G,10G,1G]"
+        }
+    }
+}

--- a/tests/platform_json/platform.json
+++ b/tests/platform_json/platform.json
@@ -1,0 +1,117 @@
+{
+    "chassis": {
+        "name": "",
+        "components": [],
+        "fans": [],
+        "fan_drawers": [],
+        "psus": [],
+        "thermals": [],
+        "sfps": []
+    },
+    "interfaces": {
+        "Ethernet0": {
+            "index": "1,1,1,1",
+            "lanes": "29,30,31,32",
+            "breakout_modes": {
+                "1x200G[100G,50G,40G,25G,10G,1G]": ["etp1"],
+                "2x100G[50G,25G,10G,1G]": ["etp1a", "etp1b"]
+            }
+        },
+        "Ethernet4": {
+            "index": "2,2,2,2",
+            "lanes": "25,26,27,28",
+            "breakout_modes": {
+                "1x200G[100G,50G,40G,25G,10G,1G]": ["etp2"],
+                "2x100G[50G,25G,10G,1G]": ["etp2a", "etp2b"]
+            }
+        },
+        "Ethernet8": {
+            "index": "3,3,3,3",
+            "lanes": "37,38,39,40",
+            "breakout_modes": {
+                "1x200G[100G,50G,40G,25G,10G,1G]": ["etp3"],
+                "2x100G[50G,25G,10G,1G]": ["etp3a", "etp3b"]
+            }
+        },
+        "Ethernet12": {
+            "index": "4,4,4,4",
+            "lanes": "33,34,35,36",
+            "breakout_modes": {
+                "1x200G[100G,50G,40G,25G,10G,1G]": ["etp4"],
+                "2x100G[50G,25G,10G,1G]": ["etp4a", "etp4b"]
+            }
+        },
+        "Ethernet16": {
+            "index": "5,5,5,5",
+            "lanes": "41,42,43,44",
+            "breakout_modes": {
+                "1x200G[100G,50G,40G,25G,10G,1G]": ["etp5"],
+                "2x100G[50G,25G,10G,1G]": ["etp5a", "etp5b"]
+            }
+        },
+        "Ethernet20": {
+            "index": "6,6,6,6",
+            "lanes": "44,46,47,48",
+            "breakout_modes": {
+                "1x200G[100G,50G,40G,25G,10G,1G]": ["etp6"],
+                "2x100G[50G,25G,10G,1G]": ["etp6a", "etp6b"]
+            }
+        },
+        "Ethernet24": {
+            "index": "7,7,7,7",
+            "lanes": "5,6,7,8",
+            "breakout_modes": {
+                "1x200G[100G,50G,40G,25G,10G,1G]": ["etp7"],
+                "2x100G[50G,25G,10G,1G]": ["etp7a", "etp7b"]
+            }
+        },
+        "Ethernet28": {
+            "index": "8,8,8,8",
+            "lanes": "1,2,3,4",
+            "breakout_modes": {
+                "1x200G[100G,50G,40G,25G,10G,1G]": ["etp8"],
+                "2x100G[50G,25G,10G,1G]": ["etp8a", "etp8b"]
+            }
+        },
+        "Ethernet32": {
+            "index": "9,9,9,9",
+            "lanes": "9,10,11,12",
+            "breakout_modes": {
+                "1x200G[100G,50G,40G,25G,10G,1G]": ["etp9"],
+                "2x100G[50G,25G,10G,1G]": ["etp9a", "etp9b"]
+            }
+        },
+        "Ethernet36": {
+            "index": "10,10,10,10",
+            "lanes": "13,14,15,16",
+            "breakout_modes": {
+                "1x200G[100G,50G,40G,25G,10G,1G]": ["etp10"],
+                "2x100G[50G,25G,10G,1G]": ["etp10a", "etp10b"]
+            }
+        },
+        "Ethernet40": {
+            "index": "11,11,11,11",
+            "lanes": "21,22,23,24",
+            "breakout_modes": {
+                "1x200G[100G,50G,40G,25G,10G,1G]": ["etp11"],
+                "2x100G[50G,25G,10G,1G]": ["etp11a", "etp11b"]
+            }
+        },
+        "Ethernet44": {
+            "index": "12,12,12,12",
+            "lanes": "17,18,19,20",
+            "breakout_modes": {
+                "1x200G[100G,50G,40G,25G,10G,1G]": ["etp12"],
+                "2x100G[50G,25G,10G,1G]": ["etp12a", "etp12b"]
+            }
+        },
+        "Ethernet48": {
+            "index": "13,13,13,13",
+            "lanes": "49,50,51,51",
+            "breakout_modes": {
+                "1x200G[100G,50G,40G,25G,10G,1G]": ["etp13"],
+                "2x100G[50G,25G,10G,1G]": ["etp13a", "etp13b"]
+            }
+        }
+    }
+}

--- a/tests/sfputilhelper_test.py
+++ b/tests/sfputilhelper_test.py
@@ -4,36 +4,75 @@ import sys
 import pytest
 
 from sonic_platform_base.sonic_sfp import sfputilhelper
+from unittest import mock
 
+PORT_LIST = [
+    "Ethernet0",
+    "Ethernet4",
+    "Ethernet8",
+    "Ethernet12",
+    "Ethernet16",
+    "Ethernet20",
+    "Ethernet24",
+    "Ethernet28",
+    "Ethernet32",
+    "Ethernet36",
+    "Ethernet40",
+    "Ethernet44",
+    "Ethernet48"
+]
+
+LOGICAL_TO_PHYSICAL ={
+    'Ethernet0': [1],
+    'Ethernet4': [2],
+    'Ethernet8': [3],
+    'Ethernet12': [4],
+    'Ethernet16': [5],
+    'Ethernet20': [6],
+    'Ethernet24': [7],
+    'Ethernet28': [8],
+    'Ethernet32': [9],
+    'Ethernet36': [10],
+    'Ethernet40': [11],
+    'Ethernet44': [12],
+    'Ethernet48': [13]
+}
+
+PHYSICAL_TO_LOGICAL = {
+    1: ['Ethernet0'],
+    2: ['Ethernet4'],
+    3: ['Ethernet8'],
+    4: ['Ethernet12'],
+    5: ['Ethernet16'],
+    6: ['Ethernet20'],
+    7: ['Ethernet24'],
+    8: ['Ethernet28'],
+    9: ['Ethernet32'],
+    10: ['Ethernet36'],
+    11: ['Ethernet40'],
+    12: ['Ethernet44'],
+    13: ['Ethernet48']
+}
+
+test_dir = os.path.dirname(os.path.realpath(__file__))
+hwsku_json_file = os.path.join(test_dir, 'platform_json', 'hwsku.json')
 
 @pytest.fixture(scope="class")
 def setup_class(request):
     # Configure the setup
-    test_dir = os.path.dirname(os.path.realpath(__file__))
     request.cls.port_config_file = os.path.join(test_dir, 'port_config.ini')
+    request.cls.platform_dir = os.path.dirname(os.path.realpath(__file__))
+    request.cls.platform_json_dir = os.path.join(test_dir, 'platform_json')
 
 
 @pytest.mark.usefixtures("setup_class")
 class TestSfpUtilHelper(object):
 
     port_config_file = None
+    platform_dir = None
+    platform_json_dir = None
 
     def test_read_port_mappings(self):
-        PORT_LIST = [
-            "Ethernet0",
-            "Ethernet4",
-            "Ethernet8",
-            "Ethernet12",
-            "Ethernet16",
-            "Ethernet20",
-            "Ethernet24",
-            "Ethernet28",
-            "Ethernet32",
-            "Ethernet36",
-            "Ethernet40",
-            "Ethernet44",
-            "Ethernet48"
-        ]
 
         sfputil_helper = sfputilhelper.SfpUtilHelper()
         sfputil_helper.read_porttab_mappings(self.port_config_file, 0)
@@ -43,3 +82,36 @@ class TestSfpUtilHelper(object):
 
         for logical_port_name in logical_port_list:
             assert logical_port_name in PORT_LIST
+
+
+    @mock.patch('portconfig.get_hwsku_file_name', mock.MagicMock(return_value=hwsku_json_file))
+    def test_read_all_port_mappings(self):
+
+        sfputil_helper = sfputilhelper.SfpUtilHelper()
+        sfputil_helper.logical = []
+        sfputil_helper.logical_to_physical = {}
+        sfputil_helper.physical_to_logica = {}
+        sfputil_helper.read_all_porttab_mappings(self.platform_dir, 2)
+        logical_port_list = sfputil_helper.logical
+
+        assert len(logical_port_list) == len(PORT_LIST)
+        for logical_port_name in logical_port_list:
+            assert logical_port_name in PORT_LIST
+        assert sfputil_helper.logical_to_physical == LOGICAL_TO_PHYSICAL
+        assert sfputil_helper.physical_to_logical == PHYSICAL_TO_LOGICAL
+
+        # test platform.json case
+
+        sfputil_helper.logical = []
+        sfputil_helper.logical_to_physical = {}
+        sfputil_helper.physical_to_logica = {}
+        sfputil_helper.read_all_porttab_mappings(self.platform_json_dir, 2)
+        logical_port_list = sfputil_helper.logical
+
+        assert len(logical_port_list) == len(PORT_LIST)
+
+        for logical_port_name in logical_port_list:
+            assert logical_port_name in PORT_LIST
+
+        assert sfputil_helper.logical_to_physical == LOGICAL_TO_PHYSICAL
+        assert sfputil_helper.physical_to_logical == PHYSICAL_TO_LOGICAL


### PR DESCRIPTION
#### Description
read_porttab_mappings() is not able to get the multiasic  port config.   Modified function read_porttab_mapings() to pass the asic_name to allow the get_port_config() to get the port info for each asic.  Also use the extend() and update() method to update the logical, logical_to_physical, phyiscal_to_logical lists.   Also add the unit test case test_read_all_porttab_mappings() .

#### Motivation and Context
This change is required to handle the mutliasic platform. Fixes https://github.com/Azure/sonic-buildimage/issues/10569

#### How Has This Been Tested?
The following output should be displayed without any error when using CLI command: sudo sfpulti show presence
```
admin@sonic:~$ sudo sfputil show presence
Port        Presence
----------  -----------
Ethernet0   Not present
Ethernet1   Not present
Ethernet2   Present
Ethernet3   Present
Ethernet4   Not present
Ethernet5   Not present
Ethernet6   Present
Ethernet7   Not present
Ethernet8   Not present
Ethernet9   Not present
Ethernet10  Not present
Ethernet11  Not present
Ethernet12  Not present
Ethernet13  Not present
Ethernet14  Not present
Ethernet15  Not present
Ethernet16  Not present
Ethernet17  Not present
Ethernet18  Not present
Ethernet19  Not present
Ethernet20  Not present
Ethernet21  Not present
Ethernet22  Not present
Ethernet23  Not present
Ethernet24  Present
Ethernet25  Present
Ethernet26  Present
Ethernet27  Not present
Ethernet28  Not present
Ethernet29  Not present
Ethernet30  Not present
Ethernet31  Not present
Ethernet32  Not present
Ethernet33  Not present
Ethernet34  Not present
Ethernet35  Not present
admin@sonic:~$ 
```

#### Additional Information (Optional)

