### PR TITLE
Fix AttributeError for "sfputil show error-status -hw"

### DIFF
--- a/sonic_platform_base/sonic_xcvr/api/xcvr_api.py
+++ b/sonic_platform_base/sonic_xcvr/api/xcvr_api.py
@@ -463,3 +463,15 @@ class XcvrApi(object):
         result                     |tuple          |firmware information
         """
         raise NotImplementedError
+
+    def get_error_description(self):
+        """
+        Retrives the error descriptions of the SFP module
+
+        Returns:
+            String that represents the current error descriptions of vendor specific errors
+            In case there are multiple errors, they should be joined by '|',
+            like: "Bad EEPROM|Unsupported cable"
+        """
+        raise NotImplementedError
+


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

#### Description
<!--
     Describe your changes in detail
-->

When insert trasnceiver which is not QSFP-DD, "sfputil show error-status -hw" would fail
error:
```
  File "/usr/local/lib/python3.7/dist-packages/sonic_platform_base/sonic_xcvr/sfp_optoe_base.py", line 211, in get_error_description
    return api.get_error_description() if api is not None else None
AttributeError: 'Sff8636Api' object has no attribute 'get_error_description'
```
Signed-off-by: chiourung_huang <chiourung_huang@edge-core.com>

#### Motivation and Context
<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->

#### How Has This Been Tested?
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->
```
admin@as9726-32d-1:~$ sudo sfputil show error-status -hw
Port         Error Status
-----------  --------------------
Ethernet0    OK (Not implemented)
Ethernet8    OK (Not implemented)
Ethernet16   OK (Not implemented)
Ethernet24   OK (Not implemented)
Ethernet32   OK (Not implemented)
Ethernet40   OK (Not implemented)
Ethernet48   OK (Not implemented)
Ethernet56   OK (Not implemented)
Ethernet64   OK (Not implemented)
Ethernet72   OK (Not implemented)
Ethernet80   OK (Not implemented)
Ethernet88   OK (Not implemented)
Ethernet96   OK (Not implemented)
Ethernet104  OK (Not implemented)
Ethernet112  OK (Not implemented)
Ethernet120  OK (Not implemented)
Ethernet128  OK (Not implemented)
Ethernet136  OK (Not implemented)
Ethernet144  OK (Not implemented)
Ethernet152  OK (Not implemented)
Ethernet160  OK (Not implemented)
Ethernet168  OK (Not implemented)
Ethernet176  OK (Not implemented)
Ethernet184  OK (Not implemented)
Ethernet192  OK (Not implemented)
Ethernet200  OK (Not implemented)
Ethernet208  OK (Not implemented)
Ethernet216  OK (Not implemented)
Ethernet224  OK (Not implemented)
Ethernet232  OK (Not implemented)
Ethernet240  OK (Not implemented)
Ethernet248  OK (Not implemented)
Ethernet256  OK (Not implemented)
```
#### Additional Information (Optional)

